### PR TITLE
[4.4][opensearch] Adds initial draft docs

### DIFF
--- a/content/chapter-destinations/configuring-destinations-elasticsearch-http/_index.md
+++ b/content/chapter-destinations/configuring-destinations-elasticsearch-http/_index.md
@@ -15,7 +15,7 @@ HTTPS connection, as well as password- and certificate-based authentication is s
    d_elasticsearch_http {
         elasticsearch-http(
             index("<elasticsearch-index-to-store-messages>")
-            url("https://your-elasticsearch-server1:9200/_bulk" "https://your-elasticsearch-server2:9200/_bulk")
+            url("https://your-elasticsearch-server1:9200/_bulk")
             type("<type-of-the-index>")
         );
     };
@@ -35,7 +35,7 @@ HTTPS connection, as well as password- and certificate-based authentication is s
 
 ## Example: Sending log data to Elasticsearch {#example-destination-elasticsearch-http}
 
-The following example defines a `elasticsearch-http()` destination, with only the required options.
+The following example defines an `elasticsearch-http()` destination, with only the required options.
 
 ```shell
    destination d_elasticsearch_http {

--- a/content/chapter-destinations/configuring-destinations-elasticsearch-http/elasticsearch-http-batch-mode/_index.md
+++ b/content/chapter-destinations/configuring-destinations-elasticsearch-http/elasticsearch-http-batch-mode/_index.md
@@ -15,19 +15,16 @@ In the following example, a batch consists of 100 messages, or a maximum of 512 
 
 ```shell
    destination d_elasticsearch-http {
-        elasticsearch-http(url("http://your-elasticsearch-server:9200/_bulk")
+        elasticsearch-http(
+            url("http://your-elasticsearch-server:9200/_bulk")
             index("<elasticsearch-index-to-store-messages>")
             type("")
-            url("http://your-elasticsearch-server:9200/_bulk")
             batch-lines(100)
             batch-bytes(512Kb)
             batch-timeout(10000)
         );
     };
 ```
-
-
-
 
 ## Load balancing between multiple Elasticsearch indexers {#elasticsearch-http-load-balancing}
 
@@ -50,5 +47,3 @@ The following destination sends log messages to 3 different Elasticsearch indexe
 ```
 
 {{% include-headless "chunk/http-load-balance-workers.md" %}}
-
-

--- a/content/chapter-destinations/destination-opensearch/_index.md
+++ b/content/chapter-destinations/destination-opensearch/_index.md
@@ -22,12 +22,9 @@ HTTPS connection, as well as password- and certificate-based authentication is s
     };
 ```
 
-{{< include-headless "chunk/option-dest-http-proxy.md" >}}
+## Example: Sending log data to OpenSearch {#example-destination-opensearch}
 
-
-## Example: Sending log data to Elasticsearch {#example-destination-elasticsearch-http}
-
-The following example defines a `elasticsearch-http()` destination, with only the required options.
+The following example defines an `opensearch()` destination, with only the required options.
 
 ```shell
    destination opensearch {
@@ -45,7 +42,7 @@ The following example defines a `elasticsearch-http()` destination, with only th
     };
 ```
 
-The following example uses mutually-authenticated HTTPS connection, templated index, and also sets the `type()` and some other options.
+The following example uses mutually-authenticated HTTPS connection, templated index, and also sets some other options.
 
 ```shell
    destination opensearch_https {
@@ -53,7 +50,6 @@ The following example uses mutually-authenticated HTTPS connection, templated in
             url("https://node01.example.com:9200/_bulk")
             index("test-${YEAR}${MONTH}${DAY}")
             time-zone("UTC")
-            type("test")
             workers(4)
             batch-lines(16)
             timeout(10)

--- a/content/chapter-destinations/destination-opensearch/_index.md
+++ b/content/chapter-destinations/destination-opensearch/_index.md
@@ -1,0 +1,70 @@
+---
+title: "opensearch: Sending messages to OpenSearch"
+weight:  900
+---
+<!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
+
+Available in {{% param "product.abbrev" %}} version 4.4 and later.
+
+The `opensearch()` destination can directly post log messages to [OpenSearch](https://opensearch.org/) using its HTTP endpoint.
+
+HTTPS connection, as well as password- and certificate-based authentication is supported. The content of the events is sent in JSON format.
+
+
+## Declaration:
+
+```shell
+   d_opensearch {
+        opensearch(
+            index("<opensearch-index-to-store-messages>")
+            url("https://your-opensearch-endpoint:9200/_bulk")
+        );
+    };
+```
+
+{{< include-headless "chunk/option-dest-http-proxy.md" >}}
+
+
+## Example: Sending log data to Elasticsearch {#example-destination-elasticsearch-http}
+
+The following example defines a `elasticsearch-http()` destination, with only the required options.
+
+```shell
+   destination opensearch {
+        opensearch(
+            index("<name-of-the-index>")
+            url("http://my-elastic-server:9200/_bulk")
+        );
+    };
+    
+    
+    log {
+        source(s_file);
+        destination(d_opensearch_http);
+        flags(flow-control);
+    };
+```
+
+The following example uses mutually-authenticated HTTPS connection, templated index, and also sets the `type()` and some other options.
+
+```shell
+   destination opensearch_https {
+        opensearch(
+            url("https://node01.example.com:9200/_bulk")
+            index("test-${YEAR}${MONTH}${DAY}")
+            time-zone("UTC")
+            type("test")
+            workers(4)
+            batch-lines(16)
+            timeout(10)
+            tls(
+                ca-file("ca.pem")
+                cert-file("syslog_ng.crt.pem")
+                key-file("syslog_ng.key.pem")
+                peer-verify(yes)
+            )
+        );
+    };
+```
+
+This driver is actually a reusable configuration snippet configured to send log messages using the `http()` driver using a template. For details on using or writing such configuration snippets, see {{% xref "/chapter-configuration-file/large-configs/config-blocks/_index.md" %}}. You can find the source of this configuration snippet on [GitHub](https://github.com/syslog-ng/syslog-ng/tree/master/scl/opensearch).

--- a/content/chapter-destinations/destination-opensearch/batch-mode/_index.md
+++ b/content/chapter-destinations/destination-opensearch/batch-mode/_index.md
@@ -1,0 +1,47 @@
+---
+title: "Batch mode and load balancing"
+weight:  100
+---
+<!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
+
+The `opensearch()` destination automatically sends multiple log messages in a single HTTP request, increasing the rate of messages that your Elasticsearch deployment can consume. For details on adjusting and fine-tuning the batch mode, see the following section.
+
+{{% include-headless "chunk/concept-batch-size.md" %}}
+
+## Example: HTTP batch mode {#example-elasticsearch-http-batch-mode}
+
+In the following example, a batch consists of 100 messages, or a maximum of 512 kilobytes, and is sent every 20 seconds (20000 milliseconds).
+
+```shell
+   destination d_opensearch {
+        opensearch(
+            url("http://your-server:9200/_bulk")
+            index("<index-to-store-messages>")
+            batch-lines(100)
+            batch-bytes(512Kb)
+            batch-timeout(10000)
+        );
+    };
+```
+
+## Load balancing between multiple indexers
+
+{{< include-headless "chunk/destination-load-balancing-url.md" >}}
+
+## Example: HTTP load balancing
+
+The following destination sends log messages to 3 different indexer nodes. Each node is assigned a separate worker thread. A batch consists of 100 messages, or a maximum of 512 kilobytes, and is sent every 20 seconds (20000 milliseconds).
+
+```shell
+   destination d_opensearch {
+        opensearch(
+            url("http://your-elasticsearch-server1:9200/_bulk" "http://your-elasticsearch-server2:9200/_bulk" "http://your-elasticsearch-server3:9200/_bulk")
+            batch-lines(100)
+            batch-bytes(512Kb)
+            batch-timeout(20000)
+            persist-name("opensearch-load-balance")
+        );
+    };
+```
+
+{{% include-headless "chunk/http-load-balance-workers.md" %}}

--- a/content/chapter-destinations/destination-opensearch/reference-destination-opensearch/_index.md
+++ b/content/chapter-destinations/destination-opensearch/reference-destination-opensearch/_index.md
@@ -10,7 +10,7 @@ This destination is available in {{% param "product.abbrev" %}} version 4.4 and 
 
 {{% include-headless "chunk/option-destination-batch-bytes.md" %}}
 
-For details on how this option influences batch mode, see {{% xref "/chapter-destinations/configuring-destinations-elasticsearch-http/elasticsearch-http-batch-mode/_index.md" %}}
+For details on how this option influences batch mode, see {{% xref "/chapter-destinations/destination-opensearch/batch-mode/_index.md" %}}.
 
 ## batch-lines()
 
@@ -21,23 +21,34 @@ For details on how this option influences batch mode, see {{% xref "/chapter-des
 
 {{% include-headless "chunk/option-description-destination-batch-lines.md" %}}
 
-For details on how this option influences batch mode, see {{% xref "/chapter-destinations/configuring-destinations-elasticsearch-http/elasticsearch-http-batch-mode/_index.md" %}}
-
-
+For details on how this option influences batch mode, see {{% xref "/chapter-destinations/destination-opensearch/batch-mode/_index.md" %}}.
 
 {{% include-headless "chunk/option-destination-batch-timeout.md" %}}
 
-For details on how this option influences batch mode, see {{% xref "/chapter-destinations/configuring-destinations-elasticsearch-http/elasticsearch-http-batch-mode/_index.md" %}}
-
-
+For details on how this option influences batch mode, see {{% xref "/chapter-destinations/destination-opensearch/batch-mode/_index.md" %}}.
 
 {{% include-headless "chunk/option-destination-tls-ca-dir.md" %}}
 
 {{% include-headless "chunk/topic-tls-block-http.md" %}}
 
-{{% include-headless "chunk/example-tls-block-elasticsearch-http-ca-dir.md" %}}
+### Declaration:
 
-
+```shell
+   destination d_opensearch {
+        opensearch(
+            url("http://your-server:9200/_bulk")
+            index("example-index")
+            tls(
+                ca-dir("dir")
+                cert-file("cert")
+                cipher-suite("cipher")
+                key-file("key")
+                peer-verify(yes|no)
+                ssl-version(<the permitted SSL/TLS version>)
+            )
+        );
+    };
+```
 
 ## ca-file() {#opensearch-options-ca-file}
 
@@ -50,25 +61,36 @@ For details on how this option influences batch mode, see {{% xref "/chapter-des
 
 {{% include-headless "chunk/topic-tls-block-http.md" %}}
 
-{{% include-headless "chunk/example-tls-block-elasticsearch-http-ca-file.md" %}}
+### Declaration:
 
-
+```shell
+   destination d_opensearch {
+        opensearch(
+            url("http://your-server:9200/_bulk")
+            index("example-index")
+            tls(
+                ca-file("ca")
+                cert-file("cert")
+                cipher-suite("cipher")
+                key-file("key")
+                peer-verify(yes|no)
+                ssl-version(<the permitted SSL/TLS version>)
+            )
+        );
+    };
+```
 
 {{% include-headless "chunk/option-destination-tls-cert-file.md" %}}
 
 {{% include-headless "chunk/topic-tls-block-http.md" %}}
 
-{{% include-headless "chunk/example-tls-block-elasticsearch-http.md" %}}
-
-
+{{% include-headless "chunk/example-tls-block-opensearch.md" %}}
 
 {{% include-headless "chunk/option-destination-tls-cipher-suite.md" %}}
 
 {{% include-headless "chunk/topic-tls-block-http.md" %}}
 
-{{% include-headless "chunk/example-tls-block-elasticsearch-http.md" %}}
-
-
+{{% include-headless "chunk/example-tls-block-opensearch.md" %}}
 
 ## custom-id() {#opensearch-options-custom-id}
 
@@ -79,8 +101,6 @@ For details on how this option influences batch mode, see {{% xref "/chapter-des
 
 *Description:* Sets the specified value as the ID of the OpenSearch index (`_id`).
 
-
-
 ## delimiter() {#opensearch-options-delimiter}
 
 |                  |                   |
@@ -90,13 +110,11 @@ For details on how this option influences batch mode, see {{% xref "/chapter-des
 
 *Description:* By default, {{% param "product.abbrev" %}} separates the log messages of the batch with a newline character. You can specify a different delimiter by using the `delimiter()` option.
 
-For details on how this option influences batch mode, see {{% xref "/chapter-destinations/configuring-destinations-elasticsearch-http/elasticsearch-http-batch-mode/_index.md" %}}
-
+For details on how this option influences batch mode, see {{% xref "/chapter-destinations/destination-opensearch/batch-mode/_index.md" %}}.
 
 {{< include-headless "chunk/option-destination-diskbuffer.md" >}}
 
 {{< include-headless "chunk/option-destination-hook.md" >}}
-
 
 ## index()
 
@@ -119,7 +137,7 @@ This destination supports only unencrypted key files (that is, the private key c
 
 {{% include-headless "chunk/topic-tls-block-http.md" %}}
 
-{{% include-headless "chunk/example-tls-block-elasticsearch-http.md" %}}
+{{% include-headless "chunk/example-tls-block-opensearch.md" %}}
 
 
 
@@ -132,29 +150,22 @@ This destination supports only unencrypted key files (that is, the private key c
 
 *Description:* The password that {{% param "product.abbrev" %}} uses to authenticate on the server where it sends the messages.
 
-
-
 {{< include-headless "chunk/option-peer-verify-simple.md" >}}
 
 {{% include-headless "chunk/topic-tls-block-http.md" %}}
 
-{{% include-headless "chunk/example-tls-block-elasticsearch-http.md" %}}
-
+{{% include-headless "chunk/example-tls-block-opensearch.md" %}}
 
 {{% include-headless "chunk/option-persist-name.md" %}}
 
 
 <span id="http-proxy"></span>
 
-{{% include-headless "chunk/option-destination-http-proxy.md" %}}
-
-
+{{< include-headless "chunk/option-dest-http-proxy.md" >}}
 
 {{% include-headless "chunk/option-destination-retries.md" %}}
 
 To handle HTTP error responses, if the HTTP server returns 5xx codes, {{% param "product.abbrev" %}} will attempt to resend messages until the number of attempts reaches `retries`. If the HTTP server returns 4xx codes, {{% param "product.abbrev" %}} will drop the messages.
-
-
 
 ## ssl-version() {#opensearch-options-ssl-version}
 
@@ -167,14 +178,11 @@ To handle HTTP error responses, if the HTTP server returns 5xx codes, {{% param 
 
 {{% include-headless "chunk/topic-tls-block-http.md" %}}
 
-{{% include-headless "chunk/example-tls-block-elasticsearch-http.md" %}}
-
+{{% include-headless "chunk/example-tls-block-opensearch.md" %}}
 
 {{% include-headless "chunk/option-destination-throttle.md" %}}
 
-
 {{% include-headless "chunk/option-source-time-reopen.md" %}}
-
 
 ## timeout() {#opensearch-options-timeout}
 
@@ -185,8 +193,6 @@ To handle HTTP error responses, if the HTTP server returns 5xx codes, {{% param 
 
 *Description:* The value (in seconds) to wait for an operation to complete, and attempt to reconnect the server if exceeded.
 
-
-
 ## url()
 
 |          |                                                        |
@@ -194,7 +200,7 @@ To handle HTTP error responses, if the HTTP server returns 5xx codes, {{% param 
 | Type:    | URL or list of URLs, for example, url("site1" "site2") |
 | Default: | N/A                                                    |
 
-*Description:* Specifies the hostname or IP address and optionally the port number of the OpenSearch indexer. Use a colon (`:`) after the address to specify the port number of the server. For example: `http://your-OpenSearch-indexer.server:8088/_bulk`
+*Description:* Specifies the hostname or IP address and optionally the port number of the OpenSearch indexer. Use a colon (`:`) after the address to specify the port number of the server. For example: `http://your-opensearch-indexer.server:8088/_bulk`
 
 This option is mandatory for this destination.
 
@@ -203,8 +209,6 @@ Make sure that the URL ends with `_bulk`, this is the OpenSearch API endpoint th
 In case the server on the specified URL returns a redirect request, {{% param "product.abbrev" %}} automatically follows maximum 3 redirects. Only HTTP and HTTPS based redirections are supported.
 
 {{< include-headless "chunk/destination-load-balancing-url.md" >}}
-
-
 
 ## user()
 
@@ -215,9 +219,7 @@ In case the server on the specified URL returns a redirect request, {{% param "p
 
 *Description:* The username that {{% param "product.abbrev" %}} uses to authenticate on the server where it sends the messages.
 
-
 {{% include-headless "chunk/option-destination-http-use-system-cert-store.md" %}}
-
 
 ## workers()
 

--- a/content/chapter-destinations/destination-opensearch/reference-destination-opensearch/_index.md
+++ b/content/chapter-destinations/destination-opensearch/reference-destination-opensearch/_index.md
@@ -1,0 +1,231 @@
+---
+title: "opensearch() destination options"
+weight:  300
+---
+<!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
+
+The `opensearch` destination of {{% param "product.abbrev" %}} can directly post log messages to an OpenSearch deployment using the OpenSearch Bulk API over the HTTP and Secure HTTP (HTTPS) protocols. The `opensearch` destination has the following options. The required options are: `index()` and `url()`.
+
+This destination is available in {{% param "product.abbrev" %}} version 4.4 and later.
+
+{{% include-headless "chunk/option-destination-batch-bytes.md" %}}
+
+For details on how this option influences batch mode, see {{% xref "/chapter-destinations/configuring-destinations-elasticsearch-http/elasticsearch-http-batch-mode/_index.md" %}}
+
+## batch-lines()
+
+|          |        |
+| -------- | ------ |
+| Type:    | number |
+| Default: | 25     |
+
+{{% include-headless "chunk/option-description-destination-batch-lines.md" %}}
+
+For details on how this option influences batch mode, see {{% xref "/chapter-destinations/configuring-destinations-elasticsearch-http/elasticsearch-http-batch-mode/_index.md" %}}
+
+
+
+{{% include-headless "chunk/option-destination-batch-timeout.md" %}}
+
+For details on how this option influences batch mode, see {{% xref "/chapter-destinations/configuring-destinations-elasticsearch-http/elasticsearch-http-batch-mode/_index.md" %}}
+
+
+
+{{% include-headless "chunk/option-destination-tls-ca-dir.md" %}}
+
+{{% include-headless "chunk/topic-tls-block-http.md" %}}
+
+{{% include-headless "chunk/example-tls-block-elasticsearch-http-ca-dir.md" %}}
+
+
+
+## ca-file() {#opensearch-options-ca-file}
+
+|                  |          |
+| ---------------- | -------- |
+| Accepted values: | Filename |
+| Default:         | none     |
+
+*Description:* Name of a file that contains an X.509 CA certificate (or a certificate chain) in PEM format. The {{% param "product.abbrev" %}} application uses this certificate to validate the certificate of the HTTPS server. If the file contains a certificate chain, the file must begin with the certificate of the host, followed by the CA certificate that signed the certificate of the host, and any other signing CAs in order.
+
+{{% include-headless "chunk/topic-tls-block-http.md" %}}
+
+{{% include-headless "chunk/example-tls-block-elasticsearch-http-ca-file.md" %}}
+
+
+
+{{% include-headless "chunk/option-destination-tls-cert-file.md" %}}
+
+{{% include-headless "chunk/topic-tls-block-http.md" %}}
+
+{{% include-headless "chunk/example-tls-block-elasticsearch-http.md" %}}
+
+
+
+{{% include-headless "chunk/option-destination-tls-cipher-suite.md" %}}
+
+{{% include-headless "chunk/topic-tls-block-http.md" %}}
+
+{{% include-headless "chunk/example-tls-block-elasticsearch-http.md" %}}
+
+
+
+## custom-id() {#opensearch-options-custom-id}
+
+|                  |              |
+| ---------------- | ------------ |
+| Accepted values: | string       |
+| Default:         | empty string |
+
+*Description:* Sets the specified value as the ID of the OpenSearch index (`_id`).
+
+
+
+## delimiter() {#opensearch-options-delimiter}
+
+|                  |                   |
+| ---------------- | ----------------- |
+| Accepted values: | string            |
+| Default:         | newline character |
+
+*Description:* By default, {{% param "product.abbrev" %}} separates the log messages of the batch with a newline character. You can specify a different delimiter by using the `delimiter()` option.
+
+For details on how this option influences batch mode, see {{% xref "/chapter-destinations/configuring-destinations-elasticsearch-http/elasticsearch-http-batch-mode/_index.md" %}}
+
+
+{{< include-headless "chunk/option-destination-diskbuffer.md" >}}
+
+{{< include-headless "chunk/option-destination-hook.md" >}}
+
+
+## index()
+
+|                  |                    |
+| ---------------- | ------------------ |
+| Accepted values: | string or template |
+| Default:         | None               |
+
+*Description:* The name of the OpenSearch index where OpenSearch will store the messages received from {{% param "product.abbrev" %}}. This option is mandatory for this destination.
+
+You can use macros and template functions, but you must ensure that the resolved template contains only characters that OpenSearch permits in the name of the index. The {{% param "product.abbrev" %}} application does not validate the name of the index. For details on the characters permitted in the name of OpenSearch indices, see the documentation of OpenSearch.
+
+
+{{% include-headless "chunk/option-destination-log-fifo-size.md" %}}
+
+
+{{% include-headless "chunk/option-destination-tls-key-file.md" %}}
+
+This destination supports only unencrypted key files (that is, the private key cannot be password-protected).
+
+{{% include-headless "chunk/topic-tls-block-http.md" %}}
+
+{{% include-headless "chunk/example-tls-block-elasticsearch-http.md" %}}
+
+
+
+## password()
+
+|          |        |
+| -------- | ------ |
+| Type:    | string |
+| Default: |        |
+
+*Description:* The password that {{% param "product.abbrev" %}} uses to authenticate on the server where it sends the messages.
+
+
+
+{{< include-headless "chunk/option-peer-verify-simple.md" >}}
+
+{{% include-headless "chunk/topic-tls-block-http.md" %}}
+
+{{% include-headless "chunk/example-tls-block-elasticsearch-http.md" %}}
+
+
+{{% include-headless "chunk/option-persist-name.md" %}}
+
+
+<span id="http-proxy"></span>
+
+{{% include-headless "chunk/option-destination-http-proxy.md" %}}
+
+
+
+{{% include-headless "chunk/option-destination-retries.md" %}}
+
+To handle HTTP error responses, if the HTTP server returns 5xx codes, {{% param "product.abbrev" %}} will attempt to resend messages until the number of attempts reaches `retries`. If the HTTP server returns 4xx codes, {{% param "product.abbrev" %}} will drop the messages.
+
+
+
+## ssl-version() {#opensearch-options-ssl-version}
+
+|          |                                |
+| -------- | ------------------------------ |
+| Type:    | string                         |
+| Default: | None, uses the libcurl default |
+
+*Description:* Specifies the permitted SSL/TLS version. Possible values: `sslv2`, `sslv3`, `tlsv1`, `tlsv1_0`, `tlsv1_1`, `tlsv1_2`, `tlsv1_3`.
+
+{{% include-headless "chunk/topic-tls-block-http.md" %}}
+
+{{% include-headless "chunk/example-tls-block-elasticsearch-http.md" %}}
+
+
+{{% include-headless "chunk/option-destination-throttle.md" %}}
+
+
+{{% include-headless "chunk/option-source-time-reopen.md" %}}
+
+
+## timeout() {#opensearch-options-timeout}
+
+|          |                    |
+| -------- | ------------------ |
+| Type:    | number [seconds] |
+| Default: | 10                 |
+
+*Description:* The value (in seconds) to wait for an operation to complete, and attempt to reconnect the server if exceeded.
+
+
+
+## url()
+
+|          |                                                        |
+| -------- | ------------------------------------------------------ |
+| Type:    | URL or list of URLs, for example, url("site1" "site2") |
+| Default: | N/A                                                    |
+
+*Description:* Specifies the hostname or IP address and optionally the port number of the OpenSearch indexer. Use a colon (`:`) after the address to specify the port number of the server. For example: `http://your-OpenSearch-indexer.server:8088/_bulk`
+
+This option is mandatory for this destination.
+
+Make sure that the URL ends with `_bulk`, this is the OpenSearch API endpoint that properly parses the messages sent by {{% param "product.abbrev" %}}.
+
+In case the server on the specified URL returns a redirect request, {{% param "product.abbrev" %}} automatically follows maximum 3 redirects. Only HTTP and HTTPS based redirections are supported.
+
+{{< include-headless "chunk/destination-load-balancing-url.md" >}}
+
+
+
+## user()
+
+|          |        |
+| -------- | ------ |
+| Type:    | string |
+| Default: |        |
+
+*Description:* The username that {{% param "product.abbrev" %}} uses to authenticate on the server where it sends the messages.
+
+
+{{% include-headless "chunk/option-destination-http-use-system-cert-store.md" %}}
+
+
+## workers()
+
+|          |         |
+| -------- | ------- |
+| Type:    | integer |
+| Default: | 4       |
+
+{{< include-headless "chunk/option-destination-description-workers.md" >}}
+
+{{% include-headless "chunk/http-load-balance-workers.md" %}}

--- a/content/headless/chunk/concept-batch-size.md
+++ b/content/headless/chunk/concept-batch-size.md
@@ -6,9 +6,8 @@
 
 The `batch-bytes()`, `batch-lines()`, and `batch-timeout()` options of the destination determine how many log messages {{% param "product.abbrev" %}} sends in a batch. The `batch-lines()` option determines the maximum number of messages {{% param "product.abbrev" %}} puts in a batch in. This can be limited based on size and time:
 
-  - {{% param "product.abbrev" %}} sends a batch every `batch-timeout()` milliseconds, even if the number of messages in the batch is less than `batch-lines()`. That way the destination receives every message in a timely manner even if suddenly there are no more messages.
+- {{% param "product.abbrev" %}} sends a batch every `batch-timeout()` milliseconds, even if the number of messages in the batch is less than `batch-lines()`. That way the destination receives every message in a timely manner even if suddenly there are no more messages.
 
-  - {{% param "product.abbrev" %}} sends the batch if the total size of the messages in the batch reaches `batch-bytes()` bytes.
+- {{% param "product.abbrev" %}} sends the batch if the total size of the messages in the batch reaches `batch-bytes()` bytes.
 
 To increase the performance of the destination, increase the number of worker threads for the destination using the `workers()` option, or adjust the `batch-bytes()`, `batch-lines()`, `batch-timeout()` options.
-

--- a/content/headless/chunk/example-tls-block-opensearch.md
+++ b/content/headless/chunk/example-tls-block-opensearch.md
@@ -1,0 +1,25 @@
+---
+---
+<!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
+
+### Declaration:
+
+```shell
+   destination d_elasticsearch-http {
+        elasticsearch-http(
+            url("http://your-elasticsearch-server:9200/_bulk")
+            type("")
+            index("example-index")
+            tls(
+                ca-dir("dir")
+                ca-file("ca")
+                cert-file("cert")
+                cipher-suite("cipher")
+                key-file("key")
+                peer-verify(yes|no)
+                ssl-version(<the permitted SSL/TLS version>)
+            )
+        );
+    };
+```
+


### PR DESCRIPTION
Currently the docs reuse lots of chunks from the elasticsearch-http destination, we should discuss which ones we can generalize and which ones are specific to elasticsearch