### PR TITLE
syslog-ng-otlp: add missing port() in example

### DIFF
--- a/content/headless/chunk/syslog-ng-otlp-intro.md
+++ b/content/headless/chunk/syslog-ng-otlp-intro.md
@@ -19,6 +19,6 @@ destination d_syslog_ng_otlp {
 
 ```shell
 source s_syslog_ng_otlp {
-  syslog-ng-otlp();
+  syslog-ng-otlp(port(12346));
 };
 ```


### PR DESCRIPTION
Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>
