### PR TITLE
Hide search page from section toc

### DIFF
--- a/content/search.md
+++ b/content/search.md
@@ -2,6 +2,7 @@
 title: Search this site
 type: docs
 toc_hide: true
+hide_summary: true
 ---
 <!-- This file is under the copyright of Axoflow, and licensed under Apache License 2.0, except for using the Axoflow and AxoSyslog trademarks. -->
 {{< search-form >}}


### PR DESCRIPTION
Do not show the search page at the bottom of the main page