### PR TITLE
Fix stats(level()) formatting

### DIFF
--- a/content/chapter-global-options/reference-options/_index.md
+++ b/content/chapter-global-options/reference-options/_index.md
@@ -491,8 +491,8 @@ options {
 
 |                  |                               |
 | ---------------- | ----------------------------- |
-| Accepted values: | `0 | 1 | 2 | 3` |
-| Default:         | `0`                         |
+| Accepted values: | `0`, `1`, `2`, `3`            |
+| Default:         | `0`                           |
 
 *Description:* Specifies the detail of statistics {{% param "product.abbrev" %}} collects about the processed messages.
 


### PR DESCRIPTION
It's broken https://axoflow.com/docs/axosyslog-core/chapter-global-options/reference-options/#global-option-stats-level