### PR TITLE
Unrelated clarifications

### DIFF
--- a/content/chapter-destinations/clickhouse/_index.md
+++ b/content/chapter-destinations/clickhouse/_index.md
@@ -23,11 +23,12 @@ ClickHouse Cloud doesn't support the gRPC interface currently.
     - the name of an existing database and a table where you want to send your data, and
     - the credentials (username and password) to access the database.
 
-Example configuration (sends data to the default `localhost:9100` URL):
+Example configuration:
 
 ```sh
 destination {
   clickhouse(
+    url("localhost:9100")
     database("default")
     table("demo_table")
     user("your-username")
@@ -226,7 +227,7 @@ By default, sending data to ClickHouse doesn't propagate the type information of
 | Type:    | string |
 | Default: | `localhost:9100` |
 
-*Description:* The URL of the gRPC receiver.
+*Description:* The address of the gRPC receiver in a `host:port` format. If the port is omitted, it will default to `443`. Examples: `127.0.0.1:9100`, `[::1]:1234`, `example.com` (equivalent to `example.com:443`).
 
 ## user()
 

--- a/content/chapter-encrypted-transport-tls/tls-mutualauth/procedure-configuring-mutual-tls-server/_index.md
+++ b/content/chapter-encrypted-transport-tls/tls-mutualauth/procedure-configuring-mutual-tls-server/_index.md
@@ -69,3 +69,4 @@ Complete the following steps on the AxoSyslog server:
 Do not forget to update the certificate and key files when they expire.
     {{% /alert %}}
 
+> Note: identifiers of the certificate presented by the clients will be available under the `.tls.x509_*` macros. See {{% xref "/chapter-manipulating-messages/customizing-message-format/reference-macros/_index.md#macro-tls-x509" %}}.


### PR DESCRIPTION
- **mention tls.x509_* macros when configuring an mtls source**
- **clarify clickhouse destination's url param**
