### PR TITLE
remove obsolete limitation for cache_json_file

### DIFF
--- a/content/filterx/function-reference.md
+++ b/content/filterx/function-reference.md
@@ -45,10 +45,6 @@ filterx {
 }
 ```
 
-{{% alert title="Note" color="info" %}}
-{{< product >}} reloads the contents of the JSON file only when the {{< product >}} configuration is reloaded.
-{{% /alert %}}
-
 ## datetime
 
 Cast a value into a datetime variable.


### PR DESCRIPTION
This is no longer true, `cache_json_file()` automatically reloads when a change happens to the file.