### PR TITLE
Metrics and statistics cleanup

### DIFF
--- a/content/app-man-syslog-ng/syslog-ng-ctl.1.md
+++ b/content/app-man-syslog-ng/syslog-ng-ctl.1.md
@@ -267,7 +267,7 @@ The `stats` command has the following options:
     Display legacy metrics in Prometheus-compatible format.
 
     {{% alert title="Note" color="info" %}}
-The [`stats(lifetime())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-lifetime" >}}) can be used to do the same automatically and periodically, but `stats-lifetime()` removes only dynamic counters that have a timestamp field set.
+The [`stats(lifetime())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-lifetime" >}}) can be used to do the same automatically and periodically, but `stats(lifetime())` removes only dynamic counters that have a timestamp field set.
     {{% /alert %}}
 
 ## Handling password-protected private keys {#syslog-ng-ctl-credentials}

--- a/content/app-man-syslog-ng/syslog-ng-ctl.1.md
+++ b/content/app-man-syslog-ng/syslog-ng-ctl.1.md
@@ -57,13 +57,9 @@ To temporarily change the log levels and access the logs of `syslog-ng`, see als
 
 ## Monitor {{% param "product.abbrev" %}} metrics {#metrics}
 
-{{% param "product.abbrev" %}} provides detailed metrics about its performance and status for observability and monitoring. We recommend using Prometheus to scrape these metrics, see {{% xref "/chapter-log-statistics/prometheus-exporter/_index.md" %}} for details. To display the current metrics locally in Prometheus-compatible format, run:
+{{< include-headless "chunk/metrics-intro.md" >}}
 
-```shell
-syslog-ng-ctl stats prometheus
-```
-
-Note that which metrics are shown depends on the current value of the [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}) (you can list the available metrics by running `syslog-ng --metrics-registry`.). For details on what the metrics mean, see {{% xref "/chapter-log-statistics/metrics-reference/_index.md" %}}. Example output on `stats(level(0))`:
+Example output on `stats(level(0))`:
 
 ```shell
 syslogng_last_config_file_modification_timestamp_seconds 1764166030

--- a/content/app-man-syslog-ng/syslog-ng-ctl.1.md
+++ b/content/app-man-syslog-ng/syslog-ng-ctl.1.md
@@ -88,6 +88,10 @@ syslogng_input_events_total{id="s_src#1"} 2
 syslogng_scratch_buffers_count 14
 ```
 
+The `stats prometheus` command has the following options:
+
+{{< include-headless "chunk/syslog-ng-ctl-stats-options.md" >}}
+
 ## Access legacy statistics {#legacy-statistics}
 
 The `syslog-ng-ctl stats` and the `syslog-ng-ctl query` commands give you access to the legacy statistics of {{% param "product.abbrev" %}}. There are several newer metrics that aren't available in these statistics, so we recommend using [metrics](#metrics) instead.
@@ -242,33 +246,7 @@ destination;df_facility_dot_err;;a;processed;0
 
 The `stats` command has the following options:
 
-- `--control=<socket>` or `-c`
-
-    Specify the socket to use to access {{% param "product.abbrev" %}}. Only needed when using a non-standard socket.
-
-- `--reset=<socket>` or `-r`
-
-    Reset all statistics to zero, except for the `queued` and the `memory_usage` counters. (The `queued` counters show the number of messages in the message queue of the destination driver, waiting to be sent to the destination. The `memory_usage` counters show the amount of memory used by the messages in the different queue types (in bytes). This includes every queue used by the object, including memory buffers (log-fifo) and disk-based buffers (both reliable and non-reliable))
-
-- `--remove-orphans`
-
-    Safely removes all counters that are not referenced by any `syslog-ng stat` producer objects.
-
-    The flag can be used to prune dynamic and static counters manually. This is useful, for example, when a templated file destination produces a lot of stats. We recommend using `syslog-ng-ctl stats --remove-orphans` during each configuration reload, but only after the values of those metrics have been scraped by all scrapers.
-
-    ```shell
-    dst.file;#anon-destination0#0;/tmp/2021-08-16.log;o;processed;253592
-    dst.file;#anon-destination0#0;/tmp/2021-08-17.log;o;processed;156
-    dst.file;#anon-destination0#0;/tmp/2021-08-18.log;a;processed;961
-    ```
-
-- `--with-legacy-metrics`
-
-    Display legacy metrics in Prometheus-compatible format.
-
-    {{% alert title="Note" color="info" %}}
-The [`stats(lifetime())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-lifetime" >}}) can be used to do the same automatically and periodically, but `stats(lifetime())` removes only dynamic counters that have a timestamp field set.
-    {{% /alert %}}
+{{< include-headless "chunk/syslog-ng-ctl-stats-options.md" >}}
 
 ## Handling password-protected private keys {#syslog-ng-ctl-credentials}
 

--- a/content/app-man-syslog-ng/syslog-ng-ctl.1.md
+++ b/content/app-man-syslog-ng/syslog-ng-ctl.1.md
@@ -55,11 +55,55 @@ syslog-ng-ctl log-level verbose
 
 To temporarily change the log levels and access the logs of `syslog-ng`, see also the [`attach` command]({{< relref "#attach" >}}).
 
-<span id="syslog-ng-ctl-query"></span>
+## Monitor {{% param "product.abbrev" %}} metrics {#metrics}
 
-## syslog-ng-ctl query
+{{% param "product.abbrev" %}} provides detailed metrics about its performance and status for observability and monitoring. We recommend using Prometheus to scrape these metrics, see {{% xref "/chapter-log-statistics/prometheus-exporter/_index.md" %}} for details. To display the current metrics locally in Prometheus-compatible format, run:
 
-The {{% param "product.abbrev" %}} application stores various data, metrics, and statistics in a hash table. Every property has a name and a value. For example:
+```shell
+syslog-ng-ctl stats prometheus
+```
+
+Note that which metrics are shown depends on the current value of the [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}) (you can list the available metrics by running `syslog-ng --metrics-registry`.). For details on what the metrics mean, see {{% xref "/chapter-log-statistics/metrics-reference/_index.md" %}}. Example output on `stats(level(0))`:
+
+```shell
+syslogng_last_config_file_modification_timestamp_seconds 1764166030
+syslogng_last_successful_config_reload_timestamp_seconds 1775651576
+syslogng_memory_queue_events{address="192.168.0.111:514",driver="tcp",id="d_net#0",transport="tcp"} 0
+syslogng_memory_queue_processed_events_total{address="192.168.0.111:514",driver="tcp",id="d_net#0",transport="tcp"} 19
+syslogng_internal_events_total{result="dropped"} 0
+syslogng_internal_events_total{result="processed"} 2
+syslogng_internal_events_total{result="queued"} 0
+syslogng_output_unreachable{id="d_net#0",driver="tcp",transport="tcp",address="192.168.0.111:514"} 0
+syslogng_memory_queue_memory_usage_bytes{address="192.168.0.111:514",driver="tcp",id="d_net#0",transport="tcp"} 0
+syslogng_stats_level 0
+syslogng_output_events_total{address="192.168.0.111:514",driver="tcp",id="d_net#0",transport="tcp",result="dropped"} 0
+syslogng_output_events_total{address="192.168.0.111:514",driver="tcp",id="d_net#0",transport="tcp",result="queued"} 0
+syslogng_output_events_total{address="192.168.0.111:514",driver="tcp",id="d_net#0",transport="tcp",result="delivered"} 19
+syslogng_last_config_reload_timestamp_seconds 1775651576
+syslogng_memory_queue_capacity{address="192.168.0.111:514",driver="tcp",id="d_net#0",transport="tcp"} 1000
+syslogng_input_events_total{driver="journal",id="s_src#0"} 17
+syslogng_scratch_buffers_bytes 0
+syslogng_input_window_full_total{driver="journal",id="s_src#0"} 0
+syslogng_input_window_full_total{id="s_src#1"} 0
+syslogng_input_event_bytes_total{id="s_src#1"} 0
+syslogng_input_event_bytes_total{driver="journal",id="s_src#0"} 0
+syslogng_internal_events_queue_capacity 10000
+syslogng_input_events_total{id="s_src#1"} 2
+syslogng_scratch_buffers_count 14
+```
+
+## Access legacy statistics {#legacy-statistics}
+
+The `syslog-ng-ctl stats` and the `syslog-ng-ctl query` commands give you access to the legacy statistics of {{% param "product.abbrev" %}}. There are several newer metrics that aren't available in these statistics, so we recommend using [metrics](#metrics) instead.
+
+- [`syslog-ng-ctl query`](#syslog-ng-ctl-query) gives structured access to the selected legacy statistics.
+- [`syslog-ng-ctl stats`](#syslog-ng-ctl-stats) lists all the available legacy statistics in bulk.
+
+Exactly which statistics are available depends on your {{% param "product.abbrev" %}} configuration (that is, the sources, destinations, and other objects you have configured), and also on your [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}) settings.
+
+### Query legacy statistics {#syslog-ng-ctl-query}
+
+The {{% param "product.abbrev" %}} application stores various statistics in a hash table. Every property has a name and a value. For example:
 
 ```shell
 [syslog-ng]
@@ -76,9 +120,7 @@ You can query the nodes of this tree, and also use filters to select the informa
 
 The nodes and properties available in the tree depend on your {{% param "product.abbrev" %}} configuration (that is, the sources, destinations, and other objects you have configured), and also on your [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}) settings.
 
-<span id="syslog-ng-ctl-query-list"></span>
-
-### The list command
+#### List legacy statistics {#syslog-ng-ctl-query-list}
 
 `syslog-ng-ctl query list`
 
@@ -139,7 +181,7 @@ The `syslog-ng-ctl query list` command has the following options:
 
     Use `--reset` to set the selected counters to 0 after executing the query, except for the `queued` and the `memory_usage` counters. (The `queued` counters show the number of messages in the message queue of the destination driver, waiting to be sent to the destination. The `memory_usage` counters show the amount of memory used by the messages in the different queue types (in bytes). This includes every queue used by the object, including memory buffers (log-fifo) and disk-based buffers (both reliable and non-reliable))
 
-### Displaying statistics {#syslog-ng-ctl-query-sum}
+#### Get selected statistics {#syslog-ng-ctl-query-get}
 
 `syslog-ng-ctl query get [options]`
 
@@ -161,51 +203,14 @@ The `syslog-ng-ctl query get` command has the following options:
 - `--reset`
 
     Use `--reset` to set the selected counters to 0 after executing the query, except for the `queued` and the `memory_usage` counters. (The `queued` counters show the number of messages in the message queue of the destination driver, waiting to be sent to the destination. The `memory_usage` counters show the amount of memory used by the messages in the different queue types (in bytes). This includes every queue used by the object, including memory buffers (log-fifo) and disk-based buffers (both reliable and non-reliable))
-<span id="syslog-ng-ctl-stats"></span>
 
-## The stats command {#syslog-ng-ctl-stats}
+### The stats command {#syslog-ng-ctl-stats}
 
-`stats [options]`
+`syslog-ng-ctl stats [options]`
 
-Use the `stats` command to display the legacy statistics about the processed messages.
+Use the `stats` command to display the legacy statistics about the processed messages. Exactly which statistics are available depends on your {{% param "product.abbrev" %}} configuration (that is, the sources, destinations, and other objects you have configured), and also on your [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}) settings.
 
 Note that starting with version 4.14, {{< product >}} automatically shows orphan counters to avoid losing information. Information loss could happen, for example, when sending messages using short-lived (few seconds long) connections, while scraping metrics in minute intervals.
-
-The `stats` command has the following options:
-
-- `--control=<socket>` or `-c`
-
-    Specify the socket to use to access {{% param "product.abbrev" %}}. Only needed when using a non-standard socket.
-
-- `--reset=<socket>` or `-r`
-
-    Reset all statistics to zero, except for the `queued` and the `memory_usage` counters. (The `queued` counters show the number of messages in the message queue of the destination driver, waiting to be sent to the destination. The `memory_usage` counters show the amount of memory used by the messages in the different queue types (in bytes). This includes every queue used by the object, including memory buffers (log-fifo) and disk-based buffers (both reliable and non-reliable))
-
-- `--remove-orphans`
-
-    Safely removes all counters that are not referenced by any `syslog-ng stat` producer objects.
-
-    The flag can be used to prune dynamic and static counters manually. This is useful, for example, when a templated file destination produces a lot of stats. We recommend using `syslog-ng-ctl stats --remove-orphans` during each configuration reload, but only after the values of those metrics have been scraped by all scrapers.
-
-    ```shell
-    dst.file;#anon-destination0#0;/tmp/2021-08-16.log;o;processed;253592
-    dst.file;#anon-destination0#0;/tmp/2021-08-17.log;o;processed;156
-    dst.file;#anon-destination0#0;/tmp/2021-08-18.log;a;processed;961
-    ```
-
-- `--with-legacy-metrics`
-
-    Display legacy metrics in Prometheus-compatible format.
-
-    {{% alert title="Note" color="info" %}}
-The `stats-lifetime()` can be used to do the same automatically and periodically, but currently stats-lifetime() removes only dynamic counters that have a timestamp field set.
-    {{% /alert %}}
-
-### Example
-
-```shell
-syslog-ng-ctl stats
-```
 
 An example output:
 
@@ -238,6 +243,36 @@ destination;df_kern;;a;processed;70
 center;;queued;a;processed;0
 destination;df_facility_dot_err;;a;processed;0
 ```
+
+The `stats` command has the following options:
+
+- `--control=<socket>` or `-c`
+
+    Specify the socket to use to access {{% param "product.abbrev" %}}. Only needed when using a non-standard socket.
+
+- `--reset=<socket>` or `-r`
+
+    Reset all statistics to zero, except for the `queued` and the `memory_usage` counters. (The `queued` counters show the number of messages in the message queue of the destination driver, waiting to be sent to the destination. The `memory_usage` counters show the amount of memory used by the messages in the different queue types (in bytes). This includes every queue used by the object, including memory buffers (log-fifo) and disk-based buffers (both reliable and non-reliable))
+
+- `--remove-orphans`
+
+    Safely removes all counters that are not referenced by any `syslog-ng stat` producer objects.
+
+    The flag can be used to prune dynamic and static counters manually. This is useful, for example, when a templated file destination produces a lot of stats. We recommend using `syslog-ng-ctl stats --remove-orphans` during each configuration reload, but only after the values of those metrics have been scraped by all scrapers.
+
+    ```shell
+    dst.file;#anon-destination0#0;/tmp/2021-08-16.log;o;processed;253592
+    dst.file;#anon-destination0#0;/tmp/2021-08-17.log;o;processed;156
+    dst.file;#anon-destination0#0;/tmp/2021-08-18.log;a;processed;961
+    ```
+
+- `--with-legacy-metrics`
+
+    Display legacy metrics in Prometheus-compatible format.
+
+    {{% alert title="Note" color="info" %}}
+The [`stats(lifetime())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-lifetime" >}}) can be used to do the same automatically and periodically, but `stats-lifetime()` removes only dynamic counters that have a timestamp field set.
+    {{% /alert %}}
 
 ## Handling password-protected private keys {#syslog-ng-ctl-credentials}
 

--- a/content/app-man-syslog-ng/syslog-ng-ctl.1.md
+++ b/content/app-man-syslog-ng/syslog-ng-ctl.1.md
@@ -187,7 +187,7 @@ The `syslog-ng-ctl query get` command has the following options:
 
 <span id="syslog-ng-ctl-stats"></span>
 
-## The stats command
+## The stats command {#syslog-ng-ctl-stats}
 
 `stats [options]`
 

--- a/content/app-man-syslog-ng/syslog-ng-ctl.1.md
+++ b/content/app-man-syslog-ng/syslog-ng-ctl.1.md
@@ -5,9 +5,7 @@ weight: 300
 <!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
 {{< include-headless "banner-new-to-axosyslog.md" >}}
 
-<span id="syslog-ng-ctl.1"></span>
-
-## Name
+## Name {#syslog-ng-ctl.1}
 
 `syslog-ng-ctl` — Display message statistics and enable verbose, debug and trace modes
 
@@ -15,28 +13,20 @@ weight: 300
 
 `syslog-ng-ctl [command] [options]`
 
-<span id="syslog-ng-ctl-mandescription"></span>
-
 ## Description
 
 {{% alert title="Note" color="info" %}}
 
-The `syslog-ng-ctl` application is distributed with the {{% param "product.abbrev" %}} system logging application, and is usually part of the {{% param "product.abbrev" %}} package. 
+The `syslog-ng-ctl` application is distributed with the {{% param "product.abbrev" %}} system logging application, and is usually part of the {{% param "product.abbrev" %}} package.
 
 {{% /alert %}}
 
-
-
-The `syslog-ng-ctl` application is a utility that can be used to:
+The `syslog-ng-ctl` application is a utility that can:
 
 - enable/disable various {{% param "product.abbrev" %}} messages for troubleshooting
-
 - display statistics about the processed messages
-
 - handling password-protected private keys
-
 - display the currently running configuration of {{% param "product.abbrev" %}}
-
 - reload the configuration of {{% param "product.abbrev" %}}.
 
 <span id="syslog-ng-ctl"></span>
@@ -82,12 +72,9 @@ The {{% param "product.abbrev" %}} application stores various data, metrics, and
 You can query the nodes of this tree, and also use filters to select the information you need. A query is actually a path in the tree. You can also use the `?` and `*` wildcards. For example:
 
 - Select every property: `*`
-
 - Select all `dropped` value from every `stats` node: `*.stats.dropped`
 
-The nodes and properties available in the tree depend on your {{% param "product.abbrev" %}} configuration (that is, the sources, destinations, and other objects you have configured), and also on your `stats-level()` settings.
-
-
+The nodes and properties available in the tree depend on your {{% param "product.abbrev" %}} configuration (that is, the sources, destinations, and other objects you have configured), and also on your [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}) settings.
 
 <span id="syslog-ng-ctl-query-list"></span>
 
@@ -100,69 +87,63 @@ Use the `syslog-ng-ctl query list` command to display the list of metrics that {
 An example output:
 
 ```shell
-  center.received.stats.processed
-  center.queued.stats.processed
-  destination.java.d_elastic#0.java_dst(ElasticSearch,elasticsearch-syslog-ng-test,t7cde889529c034aea9ec_micek).stats.dropped
-  destination.java.d_elastic#0.java_dst(ElasticSearch,elasticsearch-syslog-ng-test,t7cde889529c034aea9ec_micek).stats.processed
-  destination.java.d_elastic#0.java_dst(ElasticSearch,elasticsearch-syslog-ng-test,t7cde889529c034aea9ec_micek).stats.queued
-  destination.d_elastic.stats.processed
-  source.s_tcp.stats.processed
-  source.severity.7.stats.processed
-  source.severity.0.stats.processed
-  source.severity.1.stats.processed
-  source.severity.2.stats.processed
-  source.severity.3.stats.processed
-  source.severity.4.stats.processed
-  source.severity.5.stats.processed
-  source.severity.6.stats.processed
-  source.facility.7.stats.processed
-  source.facility.16.stats.processed
-  source.facility.8.stats.processed
-  source.facility.17.stats.processed
-  source.facility.9.stats.processed
-  source.facility.18.stats.processed
-  source.facility.19.stats.processed
-  source.facility.20.stats.processed
-  source.facility.0.stats.processed
-  source.facility.21.stats.processed
-  source.facility.1.stats.processed
-  source.facility.10.stats.processed
-  source.facility.22.stats.processed
-  source.facility.2.stats.processed
-  source.facility.11.stats.processed
-  source.facility.23.stats.processed
-  source.facility.3.stats.processed
-  source.facility.12.stats.processed
-  source.facility.4.stats.processed
-  source.facility.13.stats.processed
-  source.facility.5.stats.processed
-  source.facility.14.stats.processed
-  source.facility.6.stats.processed
-  source.facility.15.stats.processed
-  source.facility.other.stats.processed
-  global.payload_reallocs.stats.processed
-  global.msg_clones.stats.processed
-  global.sdata_updates.stats.processed
-  tag..source.s_tcp.stats.processed
+center.received.stats.processed
+center.queued.stats.processed
+destination.java.d_elastic#0.java_dst(ElasticSearch,elasticsearch-syslog-ng-test,t7cde889529c034aea9ec_micek).stats.dropped
+destination.java.d_elastic#0.java_dst(ElasticSearch,elasticsearch-syslog-ng-test,t7cde889529c034aea9ec_micek).stats.processed
+destination.java.d_elastic#0.java_dst(ElasticSearch,elasticsearch-syslog-ng-test,t7cde889529c034aea9ec_micek).stats.queued
+destination.d_elastic.stats.processed
+source.s_tcp.stats.processed
+source.severity.7.stats.processed
+source.severity.0.stats.processed
+source.severity.1.stats.processed
+source.severity.2.stats.processed
+source.severity.3.stats.processed
+source.severity.4.stats.processed
+source.severity.5.stats.processed
+source.severity.6.stats.processed
+source.facility.7.stats.processed
+source.facility.16.stats.processed
+source.facility.8.stats.processed
+source.facility.17.stats.processed
+source.facility.9.stats.processed
+source.facility.18.stats.processed
+source.facility.19.stats.processed
+source.facility.20.stats.processed
+source.facility.0.stats.processed
+source.facility.21.stats.processed
+source.facility.1.stats.processed
+source.facility.10.stats.processed
+source.facility.22.stats.processed
+source.facility.2.stats.processed
+source.facility.11.stats.processed
+source.facility.23.stats.processed
+source.facility.3.stats.processed
+source.facility.12.stats.processed
+source.facility.4.stats.processed
+source.facility.13.stats.processed
+source.facility.5.stats.processed
+source.facility.14.stats.processed
+source.facility.6.stats.processed
+source.facility.15.stats.processed
+source.facility.other.stats.processed
+global.payload_reallocs.stats.processed
+global.msg_clones.stats.processed
+global.sdata_updates.stats.processed
+tag..source.s_tcp.stats.processed
 ```
 
 The `syslog-ng-ctl query list` command has the following options:
 
 - `--reset`
-    
+
     Use `--reset` to set the selected counters to 0 after executing the query, except for the `queued` and the `memory_usage` counters. (The `queued` counters show the number of messages in the message queue of the destination driver, waiting to be sent to the destination. The `memory_usage` counters show the amount of memory used by the messages in the different queue types (in bytes). This includes every queue used by the object, including memory buffers (log-fifo) and disk-based buffers (both reliable and non-reliable))
 
-
-
-<span id="syslog-ng-ctl-query-sum"></span>
-
-### Displaying metrics and statistics
+### Displaying statistics {#syslog-ng-ctl-query-sum}
 
 `syslog-ng-ctl query get [options]`
 
-The `syslog-ng-ctl query get <query>` command lists the nodes that match the query, and their values.
-
-For example, the `destination` query lists the configured destinations, and the metrics related to each destination. An example output:
+The `syslog-ng-ctl query get <query>` command lists the nodes that match the query, and their values. For example, the `destination` query lists the configured destinations, and the statistics related to each destination. An example output:
 
 ```shell
 destination.java.d_elastic#0.java_dst(ElasticSearch,elasticsearch-syslog-ng-test,t7cde889529c034aea9ec_micek).stats.dropped=0
@@ -174,24 +155,19 @@ destination.d_elastic.stats.processed=0
 The `syslog-ng-ctl query get` command has the following options:
 
 - `--sum`
-    
-    Add up the result of each matching node and return only a single number.
-    
-    For example, the `syslog-ng-ctl query get --sum "destination*.dropped"` command displays the number of messages dropped by the {{% param "product.abbrev" %}} instance.
+
+    Add up the result of each matching node and return only a single number. For example, the `syslog-ng-ctl query get --sum "destination*.dropped"` command displays the number of messages dropped by the {{% param "product.abbrev" %}} instance.
 
 - `--reset`
-    
+
     Use `--reset` to set the selected counters to 0 after executing the query, except for the `queued` and the `memory_usage` counters. (The `queued` counters show the number of messages in the message queue of the destination driver, waiting to be sent to the destination. The `memory_usage` counters show the amount of memory used by the messages in the different queue types (in bytes). This includes every queue used by the object, including memory buffers (log-fifo) and disk-based buffers (both reliable and non-reliable))
-
-
-
 <span id="syslog-ng-ctl-stats"></span>
 
 ## The stats command {#syslog-ng-ctl-stats}
 
 `stats [options]`
 
-Use the `stats` command to display statistics about the processed messages either in legacy format, or in Prometheus-compatible format (by running `syslog-ng-ctl stats prometheus`). For details about the displayed metrics, see {{% xref "/chapter-log-statistics/metrics-reference/_index.md" %}}.
+Use the `stats` command to display the legacy statistics about the processed messages.
 
 Note that starting with version 4.14, {{< product >}} automatically shows orphan counters to avoid losing information. Information loss could happen, for example, when sending messages using short-lived (few seconds long) connections, while scraping metrics in minute intervals.
 
@@ -263,17 +239,11 @@ center;;queued;a;processed;0
 destination;df_facility_dot_err;;a;processed;0
 ```
 
-<span id="syslog-ng-ctl-credentials"></span>
-
-## Handling password-protected private keys
+## Handling password-protected private keys {#syslog-ng-ctl-credentials}
 
 `syslog-ng-ctl credentials [options]`
 
-The `syslog-ng-ctl credentials status` command allows you to query the status of the private keys that {{% param "product.abbrev" %}} uses in the `network()` and `syslog()` drivers. You can also provide the passphrase for password-protected private keys using the `syslog-ng-ctl credentials add` command. For details on using password-protected keys, see [The syslog-ng Administrator Guide](https://www.syslog-ng.com).
-
-
-
-<span id="idm46098617680288"></span>
+The `syslog-ng-ctl credentials status` command allows you to query the status of the private keys that {{% param "product.abbrev" %}} uses in the `network()` and `syslog()` drivers. You can also provide the passphrase for password-protected private keys using the `syslog-ng-ctl credentials add` command.
 
 ### Displaying the status of private keys
 
@@ -296,12 +266,8 @@ Waiting for password; keyfile='private.key'
 ```
 
 - `--control=<socket>` or `-c`
-    
+
     Specify the socket to use to access {{% param "product.abbrev" %}}. Only needed when using a non-standard socket.
-
-
-
-<span id="idm46098617667936"></span>
 
 ### Opening password-protected private keys
 
@@ -326,22 +292,18 @@ echo "<passphrase-of-the-key>" | syslog-ng-ctl credentials add --id=<path-to-the
 ```
 
 - `--control=<socket>` or `-c`
-    
+
     Specify the socket to use to access {{% param "product.abbrev" %}}. Only needed when using a non-standard socket.
 
 - `--id=<path-to-the-key>` or `-i`
-    
+
     The path to the password-protected private key file. This is the same path that you use in the `key-file()` option of the {{% param "product.abbrev" %}} configuration file.
 
 - `--secret=<passphrase-of-the-key>` or `-s`
-    
+
     The password or passphrase of the private key.
 
-
-
-<span id="syslog-ng-ctl-config"></span>
-
-## Displaying the configuration
+## Displaying the configuration {#syslog-ng-ctl-config}
 
 `syslog-ng-ctl config [options]`
 
@@ -353,9 +315,7 @@ Starting with {{% param "product.name" %}} version 4.2, you can display the conf
 
 You can use the `syslog-ng-ctl list-files` command to list files referenced in your configuration, for example, certificates or external configuration files. Available in {{< product >}} 3.23.1 and later.
 
-<span id="syslog-ng-ctl-reload"></span>
-
-## Reloading the configuration
+## Reloading the configuration {#syslog-ng-ctl-reload}
 
 `syslog-ng-ctl reload [options]`
 
@@ -363,9 +323,7 @@ Use the `syslog-ng-ctl reload` command to reload the configuration file of {{% p
 
 The `syslog-ng-ctl reload` command returns 0 if the operation was successful, 1 otherwise.
 
-<span id="syslog-ng-ctl-healthcheck"></span>
-
-## The healthcheck command
+## The healthcheck command {#syslog-ng-ctl-healthcheck}
 
 Available in {{% param "product.abbrev" %}} 4.2 and later.
 
@@ -416,8 +374,6 @@ The `syslog-ng-ctl attach` command has the following parameters:
 ## Files
 
 `/opt/syslog-ng/sbin/syslog-ng-ctl`
-
-
 
 ## See also
 

--- a/content/chapter-global-options/reference-options/_index.md
+++ b/content/chapter-global-options/reference-options/_index.md
@@ -523,11 +523,11 @@ In earlier versions, the default was `600` (ten minutes).
 | Accepted values: | `0`, `1`, `2`, `3`            |
 | Default:         | `0`                           |
 
-*Description:* Specifies the detail of statistics {{% param "product.abbrev" %}} collects about the processed messages.
+*Description:* Specifies the detail of metrics and statistics {{% param "product.abbrev" %}} collects about the processed messages.
 
 {{% include-headless "chunk/option-stats-level-description.md" %}}
 
-Note that level 2 and 3 increase the memory requirements and CPU load. For details on message statistics, see {{% xref "/chapter-log-statistics/_index.md" %}}.
+Note that level 2 and 3 increase the memory requirements and CPU load. For details, see {{% xref "/chapter-log-statistics/_index.md" %}}.
 
 ### lifetime() {#global-option-stats-lifetime}
 

--- a/content/chapter-global-options/reference-options/_index.md
+++ b/content/chapter-global-options/reference-options/_index.md
@@ -565,18 +565,18 @@ In some cases, there might be even millions of dynamic counters
 
     **Example: Limiting dynamic counter clusters 1:**
 
-    If you set `stats-max-dynamics()` to `1`, and 2 programs send messages, only one of these programs will be tracked in the dynamic counters, but it will have more than one counters.
+    If you set `stats(max-dynamics())` to `1`, and 2 programs send messages, only one of these programs will be tracked in the dynamic counters, but it will have more than one counters.
 
     **Example: Limiting dynamic counter clusters 2:**
 
-    If you have 500 clients, and set `stats-max-dynamics()` to `1000`, you will have enough number of counters reserved for these clients, but at the same time, you limit the use of your resources and therefore protect your system from being overloaded.
+    If you have 500 clients, and set `stats(max-dynamics())` to `1000`, you will have enough number of counters reserved for these clients, but at the same time, you limit the use of your resources and therefore protect your system from being overloaded.
 
 - No dynamic counters:
 
-    To disable dynamic counters completely, set the value of this option to `0`. This is the recommended value if you do not use statistics, or if you are not interested in dynamic counters in particular (for example, the number of logs arriving from programs).
+    To disable dynamic counters completely, set the value of this option to `0`. This is the recommended value if you don't use statistics, or if you aren't interested in dynamic counters in particular (for example, the number of logs arriving from programs).
 
 {{% alert title="Note" color="info" %}}
-If you set a lower value to `stats-max-dynamics()` (or, any limiting value, if this option has not been configured before) and restart {{% param "product.abbrev" %}}, the changes will only be applied after `stats-freq()` time has passed. That is, the previously allocated dynamic clusters will only be removed after this time.
+If you set a lower value to `stats(max-dynamics())` (or, any limiting value, if this option hasn't been configured before) and restart {{% param "product.abbrev" %}}, the changes will only be applied after `stats(freq())` time has passed. That is, the previously allocated dynamic clusters will only be removed after this time.
 {{% /alert %}}
 
 ### syslog-stats() {#global-option-stats-syslog-stats}
@@ -594,7 +594,7 @@ Possible values:
 
 - `yes`: Enable syslog stats.
 - `no`: Disable syslog stats.
-- `auto`: Use the setting of the old [`stats-level()` option](#global-option-stats-level).
+- `auto`: Use the setting of the old [`stats(level())` option](#global-option-stats-level).
 
 ## stats-freq()
 

--- a/content/chapter-log-statistics/_index.md
+++ b/content/chapter-log-statistics/_index.md
@@ -1,21 +1,18 @@
 ---
-title: "Statistics of AxoSyslog"
+title: "Statistics and metrics of AxoSyslog"
 weight:  3700
 ---
 <!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
 
-The {{% param "product.abbrev" %}} application collects various statistics and measures different metrics about the messages it receives and delivers. These metrics are collected into different counters, depending on the configuration of {{% param "product.abbrev" %}}. The [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}) determines exactly which statistics {{% param "product.abbrev" %}} collects. You can access these statistics and metrics using the following methods.
+The {{% param "product.abbrev" %}} application collects various statistics and metrics about its performance and status for observability and monitoring. Which metrics and statistics are collected depends on the configuration of {{% param "product.abbrev" %}} and the value of the [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}).
 
-## Structured, selective methods (recommended)
+## Metrics and statistics
 
-- Using the [`syslog-ng-ctl`]({{< relref "/quickstart/managing-and-checking-linux/_index.md#stats" >}}) query command. For further information about using `syslog-ng-ctl` commands, see {{% xref "/app-man-syslog-ng/syslog-ng-ctl.1.md" %}}.
-- Using the [`axosyslog-metrics-exporter`]({{< relref "/chapter-log-statistics/prometheus-exporter/_index.md" >}}).
+- {{< include-headless "chunk/metrics-intro.md" >}}
+- Statistics are a legacy way to access the status of {{% param "product.abbrev" %}}. Metrics are newer and in active development. Many metrics aren't available as legacy statistics. You can access legacy statistics using the following methods.
 
-## Unstructured, bulk methods (legacy)
+    - The [`syslog-ng-ctl query`]({{< relref "/app-man-syslog-ng/syslog-ng-ctl.1.md#syslog-ng-ctl-query" >}}) command gives structured access to the selected legacy statistics..
+    - The [`syslog-ng-ctl stats`]({{< relref "/app-man-syslog-ng/syslog-ng-ctl.1.md#syslog-ng-ctl-stats" >}}) command lists all the available legacy statistics in bulk.
+    - Using the [`internal()` source]({{< relref "/chapter-log-statistics/log-statistics-internal-source/_index.md" >}}). We recommend using either of the previous two methods instead.
 
-- Using the [`internal()` source]({{< relref "/chapter-log-statistics/log-statistics-internal-source/_index.md" >}}).
-- Using the [`syslog-ng-ctl stats`]({{< relref "/quickstart/managing-and-checking-linux/_index.md#stats" >}}) command.
-- Use the `socat` application: `echo STATS | socat -vv UNIX-CONNECT:/opt/syslog-ng/var/run/syslog-ng.ctl -`
-- If you have an OpenBSD-style `netcat` application installed, use the `echo STATS | nc -U /opt/syslog-ng/var/run/syslog-ng.ctl` command. Note that the `netcat` included in most Linux distributions is a GNU-style version that's not suitable to query the statistics of `syslog-ng`.
-
-For further information about using `syslog-ng-ctl` commands, see {{% xref "/app-man-syslog-ng/syslog-ng-ctl.1.md#syslog-ng-ctl-stats" %}}.
+    For details about the available counters and the output format, see {{% xref "/chapter-log-statistics/log-statistics-description/_index.md" %}}.

--- a/content/chapter-log-statistics/_index.md
+++ b/content/chapter-log-statistics/_index.md
@@ -4,22 +4,18 @@ weight:  3700
 ---
 <!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
 
-The {{% param "product.abbrev" %}} application collects various statistics and measures different metrics about the messages it receives and delivers. These metrics are collected into different counters, depending on the configuration of {{% param "product.abbrev" %}}. The [`stats-level()` global option]({{< relref "/chapter-global-options/reference-options/_index.md" >}}) determines exactly which statistics {{% param "product.abbrev" %}} collects. You can access these statistics and metrics using the following methods.
+The {{% param "product.abbrev" %}} application collects various statistics and measures different metrics about the messages it receives and delivers. These metrics are collected into different counters, depending on the configuration of {{% param "product.abbrev" %}}. The [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}) determines exactly which statistics {{% param "product.abbrev" %}} collects. You can access these statistics and metrics using the following methods.
 
+## Structured, selective methods (recommended)
 
-## Recommended: Structured, selective methods:
-
-- Using the `monitoring()` source.
 - Using the [`syslog-ng-ctl`]({{< relref "/quickstart/managing-and-checking-linux/_index.md#stats" >}}) query command. For further information about using `syslog-ng-ctl` commands, see {{% xref "/app-man-syslog-ng/syslog-ng-ctl.1.md" %}}.
+- Using the [`axosyslog-metrics-exporter`]({{< relref "/chapter-log-statistics/prometheus-exporter/_index.md" >}}).
 
-## Legacy: Unstructured, bulk methods
+## Unstructured, bulk methods (legacy)
 
 - Using the [`internal()` source]({{< relref "/chapter-log-statistics/log-statistics-internal-source/_index.md" >}}).
-
 - Using the [`syslog-ng-ctl stats`]({{< relref "/quickstart/managing-and-checking-linux/_index.md#stats" >}}) command.
-  
-  For further information about using `syslog-ng-ctl` commands, see {{% xref "/app-man-syslog-ng/syslog-ng-ctl.1.md" %}}.
-
 - Use the `socat` application: `echo STATS | socat -vv UNIX-CONNECT:/opt/syslog-ng/var/run/syslog-ng.ctl -`
+- If you have an OpenBSD-style `netcat` application installed, use the `echo STATS | nc -U /opt/syslog-ng/var/run/syslog-ng.ctl` command. Note that the `netcat` included in most Linux distributions is a GNU-style version that's not suitable to query the statistics of `syslog-ng`.
 
-- If you have an OpenBSD-style `netcat` application installed, use the `echo STATS | nc -U /opt/syslog-ng/var/run/syslog-ng.ctl` command. Note that the `netcat` included in most Linux distributions is a GNU-style version that is not suitable to query the statistics of `syslog-ng`.
+For further information about using `syslog-ng-ctl` commands, see {{% xref "/app-man-syslog-ng/syslog-ng-ctl.1.md#syslog-ng-ctl-stats" %}}.

--- a/content/chapter-log-statistics/_index.md
+++ b/content/chapter-log-statistics/_index.md
@@ -9,7 +9,9 @@ The {{% param "product.abbrev" %}} application collects various statistics and m
 ## Metrics and statistics
 
 - {{< include-headless "chunk/metrics-intro.md" >}}
-- Statistics are a legacy way to access the status of {{% param "product.abbrev" %}}. Metrics are newer and in active development. Many metrics aren't available as legacy statistics. You can access legacy statistics using the following methods.
+- {{< include-headless "chunk/statistics-intro.md" >}}
+
+    You can access legacy statistics using the following methods.
 
     - The [`syslog-ng-ctl query`]({{< relref "/app-man-syslog-ng/syslog-ng-ctl.1.md#syslog-ng-ctl-query" >}}) command gives structured access to the selected legacy statistics..
     - The [`syslog-ng-ctl stats`]({{< relref "/app-man-syslog-ng/syslog-ng-ctl.1.md#syslog-ng-ctl-stats" >}}) command lists all the available legacy statistics in bulk.

--- a/content/chapter-log-statistics/log-statistics-description/_index.md
+++ b/content/chapter-log-statistics/log-statistics-description/_index.md
@@ -1,35 +1,44 @@
 ---
-title: "Metrics and counters"
-weight:  100
+title: "Statistics reference"
+weight: 1000
 ---
 <!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
 
-You can list all active metrics on your {{% param "product.abbrev" %}} host using the following command (this lists the metrics, without their current values): `syslog-ng-ctl query list "*"`
+{{< include-headless "chunk/statistics-intro.md" >}}
 
-To list the metrics and their values, use the following command: `syslog-ng-ctl query get "*"`
+You can list all active statistics on your {{% param "product.abbrev" %}} host using the following command (this lists the statistics, without their current values): `syslog-ng-ctl query list "*"`
 
-The displayed metrics have the following structure.
+## Format of statistics
 
-The type of the object (for example, `dst.file`, `tag`, `src.facility`)
+To list the statistics and their values, use the following command: `syslog-ng-ctl query get "*"`
 
-The ID of the object used in the `syslog-ng.conf` configuration file, for example, `d_internal` or `source.src_tcp`. The `#0` part means that this is the first destination in the destination group.
+Example output:
 
-The instance ID (destination) of the object, for example, the filename of a file destination, or the name of the application for a program source or destination.
+```shell
+destination.java.d_elastic#0.java_dst(ElasticSearch,elasticsearch-syslog-ng-test,t7cde889529c034aea9ec_micek).stats.dropped=0
+destination.java.d_elastic#0.java_dst(ElasticSearch,elasticsearch-syslog-ng-test,t7cde889529c034aea9ec_micek).stats.processed=0
+destination.java.d_elastic#0.java_dst(ElasticSearch,elasticsearch-syslog-ng-test,t7cde889529c034aea9ec_micek).stats.queued=0
+destination.d_elastic.stats.processed=0
 
-The status of the object. One of the following:
+```
 
-- `a` - active. At the time of querying the statistics, the source or the destination was still alive (it continuously received statistical data).
-- `d` - dynamic. Such objects may not be continuously available, for example, like statistics based on the sender's hostname. These counters only appear above a certain value of `stats-level()` global option:
+The displayed statistics have the following structure.
 
-    - `host`: source host, from `stats-level(2)`
-    - `program`: program, from `stats-level(3)`
-    - `sender`: sender host, from `stats-level(3)`
+- The type of the object (for example, `dst.file`, `tag`, `src.facility`)
+- The ID of the object used in the `syslog-ng.conf` configuration file, for example, `d_internal` or `source.src_tcp`. The `#0` part means that this is the first destination in the destination group.
+- The instance ID (destination) of the object, for example, the filename of a file destination, or the name of the application for a program source or destination.
+- The status of the object. One of the following:
 
-    ## Example: Dynamic counters
-    
-    The following example contains 6 different dynamic values: a sender, a host, and four different programs.
-    
-    ```shell
+    - `a`: active. At the time of querying the statistics, the source or the destination was still alive (it continuously received statistical data).
+    - `d`: dynamic. Such objects may not be continuously available, for example, like statistics based on the sender's hostname. These counters only appear above a certain value of `stats-level()` global option:
+
+        - `host`: source host, from `stats-level(2)`
+        - `program`: program, from `stats-level(3)`
+        - `sender`: sender host, from `stats-level(3)`
+
+        The following example contains 6 different dynamic values: a sender, a host, and four different programs.
+
+        ```shell
         src.sender;;localhost;d;processed;4
         src.sender;;localhost;d;stamp;1509121934
         src.program;;P-18069;d;processed;1
@@ -42,153 +51,131 @@ The status of the object. One of the following:
         src.program;;P-14737;d;stamp;1509121931
         src.host;;localhost;d;processed;4
         src.host;;localhost;d;stamp;1509121934
-    ```
-    
-    
-    To avoid performance issues or even overloading {{% param "product.abbrev" %}}, you might want to limit the number of registered dynamic counters in the message statistics. To do this, configure the [stats-max-dynamics()]({{< relref "/chapter-global-options/reference-options/_index.md" >}}) global option.
+        ```
 
-- `o` - This object was once active, but stopped receiving messages. (For example, a dynamic object may disappear and become orphan.)
+        To avoid performance issues or even overloading {{% param "product.abbrev" %}}, you might want to limit the number of registered dynamic counters in the message statistics. To do this, configure the [stats(max-dynamics())]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-max-dynamics" >}}) global option.
+
+    - `o`: This object was once active, but stopped receiving messages. (For example, a dynamic object may disappear and become orphan.)
 
     {{% alert title="Note" color="info" %}}
-The {{% param "product.abbrev" %}} application stores the statistics of the objects when {{% param "product.abbrev" %}} is reloaded. However, if the configuration of {{% param "product.abbrev" %}} was changed since the last reload, the statistics of orphaned objects are deleted.
+The {{% param "product.abbrev" %}} application stores the statistics of the objects when {{% param "product.abbrev" %}} is reloaded. However, if the configuration of {{% param "product.abbrev" %}} changed since the last reload, the statistics of orphaned objects are deleted.
     {{% /alert %}}
 
 The `connections` statistics counter displays the number of connections tracked by {{% param "product.abbrev" %}} for the selected source driver.
 
-
-## Example: sample configuration and statistics output
+## Example configuration and statistics output
 
 The following configuration will display the following `syslog-ng-ctl` statistics output:
 
 Configuration:
 
 ```shell
-   source s_network { 
-      tcp( 
-        port(8001)  
-      ); 
-    };
+source s_network { 
+  tcp( 
+    port(8001)  
+  ); 
+};
 ```
 
 Statistics output:
 
 ```shell
-   src.tcp;s_network#0;tcp,127.0.0.5;a;processed;1
-    src.tcp;s_network#0;tcp,127.0.0.1;a;processed;3
-    src.tcp;s_network;afsocket_sd.(stream,AF_INET(0.0.0.0:8001));a;connections;2
+src.tcp;s_network#0;tcp,127.0.0.5;a;processed;1
+src.tcp;s_network#0;tcp,127.0.0.1;a;processed;3
+src.tcp;s_network;afsocket_sd.(stream,AF_INET(0.0.0.0:8001));a;connections;2
 ```
 
+## Statistics reference
 
 The type of the statistics:
 
-`batch_size_avg`: When batching is enabled, then this shows the current average batch size of the given source or destination.
+- `batch_size_avg`: When batching is enabled, then this shows the current average batch size of the given source or destination.
+- `batch_size_max`: When batching is enabled, the value of `batch_size_max` shows the current largest batch size of the given source or destination.
+- `discarded`: The number of messages discarded by the given parser. These are messages that the parser could not parsed, and are therefore not processed. For example:
 
-`batch_size_max`: When batching is enabled, the value of `batch_size_max` shows the current largest batch size of the given source or destination.
+    ```shell
+    parser;demo_parser;;a;discarded;20
+    ```
 
-`discarded`: The number of messages discarded by the given parser. These are messages that the parser could not parsed, and are therefore not processed. For example:
+- `dropped`: The number of dropped messages. {{% param "product.abbrev" %}} could not send these messages to the destination and the output buffer got full, so messages were dropped by the destination driver, or {{% param "product.abbrev" %}} dropped the message for some other reason (for example, a parsing error).
+- `eps_last_1h`: The EPS value of the past 1 hour.
+- `eps_last_24h`: The EPS value of the past 24 hours.
+- `eps_since_start`: The EPS value since the current {{% param "product.abbrev" %}} start.
 
-```shell
-   parser;demo_parser;;a;discarded;20
-```
-
-`dropped`: The number of dropped messages — {{% param "product.abbrev" %}} could not send the messages to the destination and the output buffer got full, so messages were dropped by the destination driver, or {{% param "product.abbrev" %}} dropped the message for some other reason (for example, a parsing error).
-
-`eps_last_1h`: The EPS value of the past 1 hour.
-
-`eps_last_24h`: The EPS value of the past 24 hours.
-
-`eps_since_start`: The EPS value since the current {{% param "product.abbrev" %}} start.
-
-{{% alert title="Note" color="info" %}}
-
+    {{% alert title="Note" color="info" %}}
 When using the `eps_last_1h`, the `eps_last_24h`, and the `eps_since_start` statistics, consider the following:
 
-  - EPS stands for "event per second", and in our case, a message received or sent counts as a single event.
+- EPS stands for "event per second", and in our case, a message received or sent counts as a single event.
+- The `eps_last_1h`, the `eps_last_24h`, and the `eps_since_start` values are only approximate values.
+- The `eps_last_1h`, the `eps_last_24h`, and the `eps_since_start` values are automatically updated every `60` seconds.
+    {{% /alert %}}
 
-  - The `eps_last_1h`, the `eps_last_24h`, and the `eps_since_start` values are only approximate values.
+-  `matched`: The number of messages that are accepted by a given filter. Available for filters and similar objects (for example, a conditional rewrite rule). For example, if a filter matches a specific hostname, then the `matched` counter contains the number of messages that reached the filter from this hosts.
 
-  - The `eps_last_1h`, the `eps_last_24h`, and the `eps_since_start` values are automatically updated every `60` seconds.
+    ```shell
+    filter;demo_filter;;a;matched;28
+    ```
 
-{{% /alert %}}
+- `memory_usage`: The memory used by the messages in the different queue types (in bytes). This includes every queue used by the object, including memory buffers (log-fifo) and disk-based buffers (both reliable and non-reliable). For example:
 
-`matched`: The number of messages that are accepted by a given filter. Available for filters and similar objects (for example, a conditional rewrite rule). For example, if a filter matches a specific hostname, then the `matched` counter contains the number of messages that reached the filter from this hosts.
+    ```shell
+    dst.network;d_net#0;tcp,127.0.0.1:9999;a;memory_usage;0
+    ```
 
-```shell
-   filter;demo_filter;;a;matched;28
-```
-
-`memory_usage`: The memory used by the messages in the different queue types (in bytes). This includes every queue used by the object, including memory buffers (log-fifo) and disk-based buffers (both reliable and non-reliable). For example:
-
-```shell
-   dst.network;d_net#0;tcp,127.0.0.1:9999;a;memory_usage;0
-```
-
-{{% alert title="Note" color="info" %}}
+    {{% alert title="Note" color="info" %}}
 The memory usage (size) of queues is not equal to the memory usage (size) of the log messages in {{% param "product.abbrev" %}}. A log message can be in multiple queues, thus its size is added to multiple queue sizes. To check the size of all log messages, use `global.msg_allocated_bytes.value` metric.
-{{% /alert %}}
+    {{% /alert %}}
 
-`msg_size_max`: The current largest message size of the given source or destination.
+- `msg_size_max`: The current largest message size of the given source or destination.
+- `msg_size_avg`: The current average message size of the given source or destination.
 
-`msg_size_avg`: The current average message size of the given source or destination.
-
-{{% alert title="Note" color="info" %}}
+    {{% alert title="Note" color="info" %}}
 When using the `msg_size_avg` and `msg_size_max` statistics, consider that message sizes are calculated as follows:
 
-  - on the source side: the length of the incoming raw message
+- on the source side: the length of the incoming raw message
+- on the destination side: the length of the outgoing formatted message
+    {{% /alert %}}
 
-  - on the destination side: the length of the outgoing formatted message
-{{% /alert %}}
+- `not_matched`: The number of messages that are filtered out by a given filter. Available for filters and similar objects (for example, a conditional rewrite rule). For example, if a filter matches a specific hostname, then the `not_matched` counter contains the number of messages that reached the filter from other hosts, and so the filter discarded them.
 
-`not_matched`: The number of messages that are filtered out by a given filter. Available for filters and similar objects (for example, a conditional rewrite rule). For example, if a filter matches a specific hostname, then the `not_matched` counter contains the number of messages that reached the filter from other hosts, and so the filter discarded them.
-
-{{% alert title="Note" color="info" %}}
+    {{% alert title="Note" color="info" %}}
 Since the `not_matched` metric applies to filters, and filters are expected to discard messages that do not match the filter condition, `not_matched` messages are not included in the `dropped` metric of other objects.
 
 ```shell
-   filter;demo_filter;;a;not_matched;0
+filter;demo_filter;;a;not_matched;0
 ```
-{{% /alert %}}
 
-`processed`: The number of messages that successfully reached their destination driver.
+    {{% /alert %}}
 
-{{% alert title="Note" color="info" %}}
+- `processed`: The number of messages that successfully reached their destination driver.
+
+    {{% alert title="Note" color="info" %}}
 Consider that a message that has successfully reached its destination driver does not necessarily mean that the destination driver successfully delivered the messages as well. For example, a message can be written to disk or sent to a remote server after reaching the destination driver.
-{{% /alert %}}
+    {{% /alert %}}
 
-`queued`: The number of messages passed to the message queue of the destination driver, waiting to be sent to the destination.
-
-`stamp`: The UNIX timestamp of the last message sent to the destination.
-
-`suppressed`: The number of suppressed messages (if the `suppress()` feature is enabled).
-
-`written`: The number of messages successfully delivered to the destination. This value is calculated from other counters: `written = processed - queued - dropped`. That is, the number of messages {{% param "product.abbrev" %}} passed to the destination driver (processed) minus the number of messages that are still in the output queue of the destination driver (queued) and the number of messages dropped because of an error (dropped, for example, because {{% param "product.abbrev" %}} could not deliver the message to the destination and exceeded the number of retries).
+- `queued`: The number of messages passed to the message queue of the destination driver, waiting to be sent to the destination.
+- `stamp`: The UNIX timestamp of the last message sent to the destination.
+- `suppressed`: The number of suppressed messages (if the `suppress()` feature is enabled).
+- `written`: The number of messages successfully delivered to the destination. This value is calculated from other counters: `written = processed - queued - dropped`. That is, the number of messages {{% param "product.abbrev" %}} passed to the destination driver (processed) minus the number of messages that are still in the output queue of the destination driver (queued) and the number of messages dropped because of an error (dropped, for example, because {{% param "product.abbrev" %}} could not deliver the message to the destination and exceeded the number of retries).
 
 {{% include-headless "chunk/para-metrics-calculated-reset.md" %}}
 
 {{% alert title="Note" color="info" %}}
 Consider that for {{% param "product.abbrev" %}} version 3.36, the following statistics counters are only supported for the `http()` destination, or the `http()` destination and all `network()` sources and destinations, and all `file()` sources and destinations, respectively:
 
-  - `msg_size_max`
+- `msg_size_max`
+- `msg_size_avg`
+- `batch_size_max`
+- `batch_size_avg`
+- `eps_last_1h`
+- `eps_last_24h`
+- `eps_since_start`
 
-  - `msg_size_avg`
-
-  - `batch_size_max`
-
-  - `batch_size_avg`
-
-  - `eps_last_1h`
-
-  - `eps_last_24h`
-
-  - `eps_since_start`
 {{% /alert %}}
-
-The number of such messages.
-
 
 ## Availability of statistics
 
-Certain statistics are available only if the [`stats-level()` global option]({{< relref "/chapter-global-options/reference-options/_index.md" >}}) is set to a higher value.
+Certain statistics are available only if the [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}) is set to a higher value.
 
 {{% include-headless "chunk/option-stats-level-description.md" %}}
 
@@ -255,4 +242,3 @@ Aggregated statistics are available for different sources and destinations from 
 </tr>
 </tbody>
 </table>
-

--- a/content/chapter-log-statistics/log-statistics-description/_index.md
+++ b/content/chapter-log-statistics/log-statistics-description/_index.md
@@ -30,11 +30,11 @@ The displayed statistics have the following structure.
 - The status of the object. One of the following:
 
     - `a`: active. At the time of querying the statistics, the source or the destination was still alive (it continuously received statistical data).
-    - `d`: dynamic. Such objects may not be continuously available, for example, like statistics based on the sender's hostname. These counters only appear above a certain value of `stats-level()` global option:
+    - `d`: dynamic. Such objects may not be continuously available, for example, like statistics based on the sender's hostname. These counters only appear above a certain value of `stats(level())` global option:
 
-        - `host`: source host, from `stats-level(2)`
-        - `program`: program, from `stats-level(3)`
-        - `sender`: sender host, from `stats-level(3)`
+        - `host`: source host, from `stats(level(2))`
+        - `program`: program, from `stats(level(3))`
+        - `sender`: sender host, from `stats(level(3))`
 
         The following example contains 6 different dynamic values: a sender, a host, and four different programs.
 

--- a/content/chapter-log-statistics/log-statistics-internal-source/_index.md
+++ b/content/chapter-log-statistics/log-statistics-internal-source/_index.md
@@ -4,51 +4,51 @@ weight:  300
 ---
 <!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
 
-If the [`stats-freq()` global option]({{< relref "/chapter-global-options/reference-options/_index.md" >}}) is higher than 0, {{% param "product.abbrev" %}} periodically sends a log statistics message. This message contains statistics about the received messages, and about any lost messages since the last such message. It includes a `processed` entry for every source and destination, listing the number of messages received or sent, and a `dropped` entry including the IP address of the server for every destination where AxoSyslog has lost messages. The `center(received)` entry shows the total number of messages received from every configured sources.
+If the [`stats(freq())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-freq" >}}) is higher than 0, {{% param "product.abbrev" %}} periodically sends a log statistics message. This message contains statistics about the received messages, and about any lost messages since the last such message. It includes a `processed` entry for every source and destination, listing the number of messages received or sent, and a `dropped` entry including the IP address of the server for every destination where AxoSyslog has lost messages. The `center(received)` entry shows the total number of messages received from every configured sources.
 
 The following is a sample log statistics message for a configuration that has a single source (`s_local`) and a network and a local file destination (`d_network` and `d_local`, respectively). All incoming messages are sent to both destinations.
 
 ```shell
-   Log statistics;
-            dropped='tcp(AF_INET(192.168.10.1:514))=6439',
-            processed='center(received)=234413',
-            processed='destination(d_tcp)=234413',
-            processed='destination(d_local)=234413',
-            processed='source(s_local)=234413'
+Log statistics;
+    dropped='tcp(AF_INET(192.168.10.1:514))=6439',
+    processed='center(received)=234413',
+    processed='destination(d_tcp)=234413',
+    processed='destination(d_local)=234413',
+    processed='source(s_local)=234413'
 ```
 
 The statistics include a list of source groups and destinations, as well as the number of processed messages for each. You can control the verbosity of the statistics using the [`stats-level()` global option]({{< relref "/chapter-global-options/reference-options/_index.md" >}}). The following is an example output.
 
 ```shell
-   src.internal;s_all#0;;a;processed;6445
-    src.internal;s_all#0;;a;stamp;1268989330
-    destination;df_auth;;a;processed;404
-    destination;df_news_dot_notice;;a;processed;0
-    destination;df_news_dot_err;;a;processed;0
-    destination;d_ssb;;a;processed;7128
-    destination;df_uucp;;a;processed;0
-    source;s_all;;a;processed;7128
-    destination;df_mail;;a;processed;0
-    destination;df_user;;a;processed;1
-    destination;df_daemon;;a;processed;1
-    destination;df_debug;;a;processed;15
-    destination;df_messages;;a;processed;54
-    destination;dp_xconsole;;a;processed;671
-    dst.tcp;d_network#0;10.50.0.111:514;a;dropped;5080
-    dst.tcp;d_network#0;10.50.0.111:514;a;processed;7128
-    dst.tcp;d_network#0;10.50.0.111:514;a;queued;2048
-    destination;df_syslog;;a;processed;6724
-    destination;df_facility_dot_warn;;a;processed;0
-    destination;df_news_dot_crit;;a;processed;0
-    destination;df_lpr;;a;processed;0
-    destination;du_all;;a;processed;0
-    destination;df_facility_dot_info;;a;processed;0
-    center;;received;a;processed;0
-    destination;df_kern;;a;processed;70
-    center;;queued;a;processed;0
-    destination;df_facility_dot_err;;a;processed;0
+src.internal;s_all#0;;a;processed;6445
+src.internal;s_all#0;;a;stamp;1268989330
+destination;df_auth;;a;processed;404
+destination;df_news_dot_notice;;a;processed;0
+destination;df_news_dot_err;;a;processed;0
+destination;d_ssb;;a;processed;7128
+destination;df_uucp;;a;processed;0
+source;s_all;;a;processed;7128
+destination;df_mail;;a;processed;0
+destination;df_user;;a;processed;1
+destination;df_daemon;;a;processed;1
+destination;df_debug;;a;processed;15
+destination;df_messages;;a;processed;54
+destination;dp_xconsole;;a;processed;671
+dst.tcp;d_network#0;10.50.0.111:514;a;dropped;5080
+dst.tcp;d_network#0;10.50.0.111:514;a;processed;7128
+dst.tcp;d_network#0;10.50.0.111:514;a;queued;2048
+destination;df_syslog;;a;processed;6724
+destination;df_facility_dot_warn;;a;processed;0
+destination;df_news_dot_crit;;a;processed;0
+destination;df_lpr;;a;processed;0
+destination;du_all;;a;processed;0
+destination;df_facility_dot_info;;a;processed;0
+center;;received;a;processed;0
+destination;df_kern;;a;processed;70
+center;;queued;a;processed;0
+destination;df_facility_dot_err;;a;processed;0
 ```
 
-The statistics are semicolon separated: every line contains statistics for a particular object (for example, source, destination, tag, and so on). The statistics have the following fields:
+The statistics are semicolon separated: every line contains statistics for a particular object (like source, destination, tag).
 
 To reset the statistics to zero, use the following command: `syslog-ng-ctl stats --reset`

--- a/content/chapter-log-statistics/log-statistics-internal-source/_index.md
+++ b/content/chapter-log-statistics/log-statistics-internal-source/_index.md
@@ -1,23 +1,31 @@
 ---
 title: "Log statistics from the internal() source"
-weight:  300
+weight: 2000
 ---
 <!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
 
-If the [`stats(freq())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-freq" >}}) is higher than 0, {{% param "product.abbrev" %}} periodically sends a log statistics message. This message contains statistics about the received messages, and about any lost messages since the last such message. It includes a `processed` entry for every source and destination, listing the number of messages received or sent, and a `dropped` entry including the IP address of the server for every destination where AxoSyslog has lost messages. The `center(received)` entry shows the total number of messages received from every configured sources.
+{{% alert title="Note" color="info" %}}
+Instead of using the statistics messages of the `internal()` source, we recommend monitoring {{% param "product.abbrev" %}} using [metrics]({{< relref "/chapter-log-statistics/metrics-reference/_index.md" >}}), or if it's not possible in your environment, by [querying statistics]({{< relref "/chapter-log-statistics/log-statistics-description/_index.md" >}}).
+{{% /alert %}}
+
+If the [`stats(freq())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-freq" >}}) is higher than 0, {{% param "product.abbrev" %}} periodically sends a log statistics message. This message contains statistics about the received messages, and about any lost messages since the last such message. It includes:
+
+- a `processed` entry for every source and destination, listing the number of messages received or sent, and
+- a `dropped` entry including the IP address of the server for every destination where {{% param "product.abbrev" %}} has lost messages.
+- The `center(received)` entry shows the total number of messages received from every configured sources.
 
 The following is a sample log statistics message for a configuration that has a single source (`s_local`) and a network and a local file destination (`d_network` and `d_local`, respectively). All incoming messages are sent to both destinations.
 
 ```shell
 Log statistics;
-    dropped='tcp(AF_INET(192.168.10.1:514))=6439',
-    processed='center(received)=234413',
-    processed='destination(d_tcp)=234413',
-    processed='destination(d_local)=234413',
-    processed='source(s_local)=234413'
+dropped='tcp(AF_INET(192.168.10.1:514))=6439',
+processed='center(received)=234413',
+processed='destination(d_tcp)=234413',
+processed='destination(d_local)=234413',
+processed='source(s_local)=234413'
 ```
 
-The statistics include a list of source groups and destinations, as well as the number of processed messages for each. You can control the verbosity of the statistics using the [`stats-level()` global option]({{< relref "/chapter-global-options/reference-options/_index.md" >}}). The following is an example output.
+The statistics include a list of source groups and destinations, as well as the number of processed messages for each. You can control the verbosity of the statistics using the [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}). The following is an example output.
 
 ```shell
 src.internal;s_all#0;;a;processed;6445

--- a/content/chapter-log-statistics/metrics-reference/_index.md
+++ b/content/chapter-log-statistics/metrics-reference/_index.md
@@ -3,7 +3,9 @@ title: Metrics reference
 ---
 <!-- This file is under the copyright of Axoflow, and licensed under Apache License 2.0, except for using the Axoflow and AxoSyslog trademarks. -->
 
-The following list shows the metrics available in {{< product >}}. To export the metrics to Prometheus, see {{% xref "/chapter-log-statistics/prometheus-exporter/_index.md" %}}.
+The following list shows the metrics available in {{< product >}}.
+
+{{< include-headless "chunk/metrics-intro.md" >}}
 
 {{% alert title="Note" color="info" %}}
 - Metrics that have the `_total` suffix reset to zero when {{< product >}} is restarted. Reloading {{< product >}} doesn't cause a reset.

--- a/content/chapter-log-statistics/metrics-reference/_index.md
+++ b/content/chapter-log-statistics/metrics-reference/_index.md
@@ -1,8 +1,9 @@
 ---
 title: Metrics reference
 ---
+<!-- This file is under the copyright of Axoflow, and licensed under Apache License 2.0, except for using the Axoflow and AxoSyslog trademarks. -->
 
-The following list shows the metrics available in {{< product >}}.
+The following list shows the metrics available in {{< product >}}. To export the metrics to Prometheus, see {{% xref "/chapter-log-statistics/prometheus-exporter/_index.md" %}}.
 
 {{% alert title="Note" color="info" %}}
 - Metrics that have the `_total` suffix reset to zero when {{< product >}} is restarted. Reloading {{< product >}} doesn't cause a reset.

--- a/content/chapter-log-statistics/metrics-reference/_index.md
+++ b/content/chapter-log-statistics/metrics-reference/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Metrics reference
+weight: 300
 ---
 <!-- This file is under the copyright of Axoflow, and licensed under Apache License 2.0, except for using the Axoflow and AxoSyslog trademarks. -->
 

--- a/content/chapter-log-statistics/prometheus-exporter/_index.md
+++ b/content/chapter-log-statistics/prometheus-exporter/_index.md
@@ -8,7 +8,7 @@ Export AxoSyslog and syslog-ng metrics to Prometheus using the `axosyslog-metric
 ## Prerequisites
 
 - A running {{% param "product.name" %}} instance
-- `stats-level(2)` or higher set in your configuration file
+- `stats(level(2))` or higher set in your configuration file
 - File-level access to the {{% param "product.name" %}} control socket
 
 {{% alert title="Note" color="info" %}}

--- a/content/chapter-log-statistics/prometheus-exporter/_index.md
+++ b/content/chapter-log-statistics/prometheus-exporter/_index.md
@@ -22,8 +22,8 @@ The [`axosyslog-metrics-exporter`](https://github.com/axoflow/axosyslog-metrics-
 Run the exporter as a container:
 
 ```shell
-sudo podman run -d -p 9577:9577 -v $(echo /var/*lib/syslog-ng/syslog-ng.ctl):/syslog-ng.ctl \
-ghcr.io/axoflow/axosyslog-metrics-exporter:latest --socket.path=/syslog-ng.ctl
+sudo podman run -d -p 9577:9577 -v $(echo /var/*/syslog-ng/syslog-ng.ctl):/syslog-ng.ctl \
+  ghcr.io/axoflow/axosyslog-metrics-exporter:latest --socket.path=/syslog-ng.ctl
 ```
 
 Once started, the metrics endpoint is available at `http://127.0.0.1:9577/metrics`.

--- a/content/chapter-log-statistics/prometheus-exporter/_index.md
+++ b/content/chapter-log-statistics/prometheus-exporter/_index.md
@@ -1,12 +1,9 @@
 ---
 title: "Collect metrics with Prometheus"
 weight: 200
-description: >
-  Export AxoSyslog and syslog-ng metrics to Prometheus using the axosyslog-metrics-exporter.
 ---
 <!-- This file is under the copyright of Axoflow, and licensed under Apache License 2.0, except for using the Axoflow and AxoSyslog trademarks. -->
-
-This page shows you how to deploy the `axosyslog-metrics-exporter` to collect {{% param "product.name" %}} metrics and scrape them with Prometheus.
+Export AxoSyslog and syslog-ng metrics to Prometheus using the `axosyslog-metrics-exporter` and scrape them with Prometheus.
 
 ## Prerequisites
 

--- a/content/chapter-log-statistics/prometheus-exporter/_index.md
+++ b/content/chapter-log-statistics/prometheus-exporter/_index.md
@@ -1,0 +1,88 @@
+---
+title: "Collect metrics with Prometheus"
+weight: 200
+description: >
+  Export AxoSyslog and syslog-ng metrics to Prometheus using the axosyslog-metrics-exporter.
+---
+<!-- This file is under the copyright of Axoflow, and licensed under Apache License 2.0, except for using the Axoflow and AxoSyslog trademarks. -->
+
+This page shows you how to deploy the `axosyslog-metrics-exporter` to collect {{% param "product.name" %}} metrics and scrape them with Prometheus.
+
+## Prerequisites
+
+- A running {{% param "product.name" %}} instance
+- `stats-level(2)` or higher set in your configuration file
+- File-level access to the {{% param "product.name" %}} control socket
+
+{{% alert title="Note" color="info" %}}
+You must set `stats(level(2))` to expose host-level metrics. Without it, many metrics (including per-host counters) aren't available. For details, see the [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}).
+{{% /alert %}}
+
+## Deploy the metrics exporter
+
+The [`axosyslog-metrics-exporter`](https://github.com/axoflow/axosyslog-metrics-exporter) is a Go-based tool that exposes Prometheus-style metrics by connecting to the {{% param "product.name" %}} control socket. It works with syslog-ng, syslog-ng Premium Edition, and all versions of {{% param "product.name" %}} (syslog-ng™ is the trademark of One Identity LLC).
+
+Run the exporter as a container:
+
+```shell
+sudo podman run -d -p 9577:9577 -v $(echo /var/*lib/syslog-ng/syslog-ng.ctl):/syslog-ng.ctl \
+ghcr.io/axoflow/axosyslog-metrics-exporter:latest --socket.path=/syslog-ng.ctl
+```
+
+Once started, the metrics endpoint is available at `http://127.0.0.1:9577/metrics`.
+
+{{% alert title="Note" color="info" %}}
+The control socket is typically located at `/var/lib/syslog-ng/syslog-ng.ctl` or `/var/run/syslog-ng/syslog-ng.ctl`. In containerized environments, share the Unix domain socket with the exporter container using a volume mount, as shown in the preceding command.
+{{% /alert %}}
+
+## Configure Prometheus
+
+Create a `prometheus.yml` file with a scrape job pointing to the metrics exporter:
+
+```yaml
+scrape_configs:
+  - job_name: axosyslog
+    static_configs:
+      - targets:
+          - <prometheus-host-ip>:9577
+        labels:
+          app: axosyslog
+```
+
+Then run Prometheus:
+
+```shell
+sudo podman run \
+    -p 9090:9090 \
+    -v ./prometheus.yml:/etc/prometheus/prometheus.yml \
+    prom/prometheus
+```
+
+To verify that Prometheus is scraping correctly, open the following pages in your browser:
+
+- `http://127.0.0.1:9090/config`: shows the active configuration
+- `http://127.0.0.1:9090/targets`: shows whether the {{% param "product.name" %}} scrape target is up
+
+## Key metrics to monitor
+
+For a detailed reference, see {{% xref "/chapter-log-statistics/metrics-reference/_index.md" %}}. The main metrics that you should monitor are the following.
+
+### Critical metrics
+
+These metrics indicate problems that require immediate attention:
+
+- `output_unreachable`: destination is unavailable
+- `socket_receive_dropped_packets_total`: messages dropped on the source side
+- `output_events_total{result="dropped"}`: messages dropped at the output without flow control
+- `socket_rejected_connections_total`: number of rejected incoming connections
+
+### Core pipeline metrics
+
+These metrics give you a basic understanding of pipeline throughput:
+
+- `input_events_total`: total messages received by all sources
+- `output_events_total`: total messages sent by all destinations
+- `filtered_events_total`: total messages processed by filters
+- `parsed_events_total`: total messages processed by parsers
+- `memory_queue_events` and `disk_queue_events`: current buffer usage
+- `io_worker_latency_seconds`: I/O worker latency, a sign of potential overload

--- a/content/chapter-sources/configuring-sources-internal/_index.md
+++ b/content/chapter-sources/configuring-sources-internal/_index.md
@@ -6,32 +6,23 @@ short_description: "Collect internal messages"
 ---
 <!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
 
-All messages generated internally by AxoSyslog use this special source. To collect warnings, errors and notices from AxoSyslog itself, include this source in one of your source statements.
+All messages generated internally by {{% param "product.abbrev" %}} use the `internal()` source. To collect warnings, errors and notices from {{% param "product.abbrev" %}} itself, include this source in one of your source statements. The {{% param "product.abbrev" %}} application issues a warning upon startup if none of the defined log paths reference this driver.
 
 ```shell
-   internal()
+internal()
 ```
 
-The AxoSyslog application will issue a warning upon startup if none of the defined log paths reference this driver.
+The {{% param "product.abbrev" %}} application sends the following message types from the `internal()` source:
 
+- *fatal*: Priority value: critical (2), Facility value: syslog (5)
+- *error*: Priority value: error (3), Facility value: syslog (5)
+- *warning*: Priority value: warning (4), Facility value: syslog (5)
+- *notice*: Priority value: notice (5), Facility value: syslog (5)
+- *info*: Priority value: info (6), Facility value: syslog (5)
 
 ## Example: Using the internal() driver {#example-source-internal}
 
 ```shell
-   source s_local { internal(); };
+source s_local { internal(); };
+log { source(s_internal); destination(d_file); };
 ```
-
-
-
-## The {{% param "product.abbrev" %}} application sends the following message types from the internal() source:
-
-  - *fatal*: Priority value: critical (2), Facility value: syslog (5)
-
-  - *error*: Priority value: error (3), Facility value: syslog (5)
-
-  - *warning*: Priority value: warning (4), Facility value: syslog (5)
-
-  - *notice*: Priority value: notice (5), Facility value: syslog (5)
-
-  - *info*: Priority value: info (6), Facility value: syslog (5)
-

--- a/content/headless/chunk/metrics-intro.md
+++ b/content/headless/chunk/metrics-intro.md
@@ -1,0 +1,10 @@
+---
+---
+<!-- This file is under the copyright of Axoflow, and licensed under Apache License 2.0, except for using the Axoflow and AxoSyslog trademarks. -->
+{{% param "product.abbrev" %}} provides detailed metrics about its performance and status for observability and monitoring. We recommend using Prometheus to scrape these metrics, see {{% xref "/chapter-log-statistics/prometheus-exporter/_index.md" %}} for details. To display the current metrics locally in Prometheus-compatible format, run:
+
+```shell
+syslog-ng-ctl stats prometheus
+```
+
+Note that which metrics are shown depends on the current value of the [`stats(level())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-level" >}}) (you can list the available metrics by running `syslog-ng --metrics-registry`). For details on what the metrics mean, see {{% xref "/chapter-log-statistics/metrics-reference/_index.md" %}}.

--- a/content/headless/chunk/option-stats-level-description.md
+++ b/content/headless/chunk/option-stats-level-description.md
@@ -1,10 +1,7 @@
 ---
 ---
 <!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
-  - Level 0 collects only statistics about the sources and destinations.
-
-  - Level 1 contains details about the different connections and log files, but has a slight memory overhead.
-
-  - Level 2 contains detailed statistics based on the hostname.
-
-  - Level 3 contains detailed statistics based on various message parameters like facility, severity, or tags.
+- Level 0 collects only statistics about the sources and destinations.
+- Level 1 contains details about the different connections and log files, but has a slight memory overhead.
+- Level 2 contains detailed statistics based on the hostname.
+- Level 3 contains detailed statistics based on various message parameters like facility, severity, or tags.

--- a/content/headless/chunk/statistics-intro.md
+++ b/content/headless/chunk/statistics-intro.md
@@ -1,0 +1,4 @@
+---
+---
+<!-- This file is under the copyright of Axoflow, and licensed under Apache License 2.0, except for using the Axoflow and AxoSyslog trademarks. -->
+Statistics are a legacy way to access the status of {{% param "product.abbrev" %}}. [Metrics]({{< relref "/chapter-log-statistics/metrics-reference/_index.md" >}}) are newer and in active development. Many metrics aren't available as legacy statistics.

--- a/content/headless/chunk/syslog-ng-ctl-stats-options.md
+++ b/content/headless/chunk/syslog-ng-ctl-stats-options.md
@@ -1,0 +1,30 @@
+---
+---
+<!-- DISCLAIMER: This file is based on the syslog-ng Open Source Edition documentation https://github.com/balabit/syslog-ng-ose-guides/commit/2f4a52ee61d1ea9ad27cb4f3168b95408fddfdf2 and is used under the terms of The syslog-ng Open Source Edition Documentation License. The file has been modified by Axoflow. -->
+- `--control=<socket>` or `-c`
+
+    Specify the socket to use to access {{% param "product.abbrev" %}}. Only needed when using a non-standard socket.
+
+- `--reset=<socket>` or `-r`
+
+    Reset all statistics to zero, except for the `queued` and the `memory_usage` counters. (The `queued` counters show the number of messages in the message queue of the destination driver, waiting to be sent to the destination. The `memory_usage` counters show the amount of memory used by the messages in the different queue types (in bytes). This includes every queue used by the object, including memory buffers (log-fifo) and disk-based buffers (both reliable and non-reliable))
+
+- `--remove-orphans`
+
+    Safely removes all counters that are not referenced by any `syslog-ng stat` producer objects.
+
+    The flag can be used to prune dynamic and static counters manually. This is useful, for example, when a templated file destination produces a lot of stats. We recommend using `syslog-ng-ctl stats --remove-orphans` during each configuration reload, but only after the values of those metrics have been scraped by all scrapers.
+
+    ```shell
+    dst.file;#anon-destination0#0;/tmp/2021-08-16.log;o;processed;253592
+    dst.file;#anon-destination0#0;/tmp/2021-08-17.log;o;processed;156
+    dst.file;#anon-destination0#0;/tmp/2021-08-18.log;a;processed;961
+    ```
+
+- `--with-legacy-metrics`
+
+    Display legacy metrics in Prometheus-compatible format.
+
+    {{% alert title="Note" color="info" %}}
+The [`stats(lifetime())` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-stats-lifetime" >}}) can be used to do the same automatically and periodically, but `stats(lifetime())` removes only dynamic counters that have a timestamp field set.
+    {{% /alert %}}

--- a/content/quickstart/managing-and-checking-linux/_index.md
+++ b/content/quickstart/managing-and-checking-linux/_index.md
@@ -114,66 +114,13 @@ By default, {{% param "product.abbrev" %}} log messages (generated on the `inter
 
 Check the internal logs of {{% param "product.abbrev" %}} for any issue.
 
-<span id="stats"></span>
-
-### Message processing
-
-The {{% param "product.abbrev" %}} application collects statistics about the number of processed messages on the different sources and destinations.
-
 {{% alert title="Note" color="info" %}}
-When using `syslog-ng-ctl stats`, consider that while the output is generally consistent, there is no explicit ordering behind the command. Consequently, {{% param "product.companyabbrev" %}} does not recommend creating parsers that depend on a fix output order.
-
-If needed, you can sort the output with an external application, for example, `| sort`.
-{{% /alert %}}
-
-#### Central statistics
-
-To check the central statistics, execute the following command to see the number of received and queued (sent) messages by {{% param "product.abbrev" %}}.
-
-`watch "/opt/syslog-ng/sbin/syslog-ng-ctl stats | grep ^center"`
-
-The output will be updated in every 2 seconds. If the numbers are changing, {{% param "product.abbrev" %}} is processing the messages. Output example:
-
-```shell
-    Every 2.0s: /opt/syslog-ng/sbin/syslog-ng-ctl stats | grep ^center       Tue Jun 25 10:33:25 2019
-    center;;queued;a;processed;112
-    center;;received;a;processed;28
-```
-
-#### Source statistics
-
-To check the source statistics, execute the following command to see the number of received messages on the configured sources.
-
-`watch "/opt/syslog-ng/sbin/syslog-ng-ctl stats | grep ^source"`
-
-The output will be updated in every 2 seconds. If the numbers are changing, {{% param "product.abbrev" %}} is receiving messages on the sources. Output example:
-
-```shell
-    Every 2.0s: /opt/syslog-ng/sbin/syslog-ng-ctl stats | grep ^source      Tue Jun 25 10:40:50 2019
-    source;s_null;;a;processed;0
-    source;s_net;;a;processed;0
-    source;s_local;;a;processed;90
-```
-
-#### Destination statistics
-
-To check the source statistics, execute the following command to see the number of received messages on the configured sources.
-
-`watch "/opt/syslog-ng/sbin/syslog-ng-ctl stats | grep ^source"`
-
-The output will be updated in every 2 seconds. If the numbers are changing, {{% param "product.abbrev" %}} is receiving messages on the sources. Output example:
-
-```shell
-    Every 2.0s: /opt/syslog-ng/sbin/syslog-ng-ctl stats | grep ^destination      Tue Jun 25 10:41:02 2019
-    destination;d_logserver2;;a;processed;90
-    destination;d_messages;;a;processed;180
-    destination;d_logserver;;a;processed;90
-    destination;d_null;;a;processed;0
-```
-
-{{% alert title="Note" color="info" %}}
-If you find error messages in the internal logs, messages are not processed by {{% param "product.abbrev" %}} or you encounter any issue, you have the following options:
+If you find error messages in the internal logs, messages aren't processed by {{% param "product.abbrev" %}}, or you encounter any issue, you have the following options:
 
 - [Open a GitHub issue](https://github.com/axoflow/axosyslog/issues) including the results.
 - {{% param "product.contact" %}}
 {{% /alert %}}
+
+### Monitor {{% param "product.abbrev" %}} {#stats}
+
+To monitor the performance and status of {{% param "product.abbrev" %}} for observability and monitoring, see {{% xref "/chapter-log-statistics/_index.md" %}}.


### PR DESCRIPTION
Adds a page about Axosyslog metrics exporter
Prefer metrics instead of legacy statistics
Cleanups and restructuring in the statistics chapter