### PR TITLE
Markdown output

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,7 +59,12 @@ jobs:
 
       - name: Pagefind search index
         run: npm_config_yes=true npx pagefind --output-subdir pagefind --site ./public
-      
+
+      - name: Convert HTML to Markdown
+        run: |
+          pip install beautifulsoup4 html2text
+          python themes/docsy-axoflow/scripts/hugo_to_markdown.py --input public --output public
+
       - name: Deploy to Cloudflare R2
         env:
           AWS_S3_BUCKET: 'axosyslog-core-docs'

--- a/README.md
+++ b/README.md
@@ -51,3 +51,32 @@ To use this repository, you need the following installed locally:
 
     - `error: failed to transform resource: TOCSS: failed to transform "scss/main.scss" (text/x-scss): this feature is not available in your current Hugo version`: You have installed the regular version of Hugo, not the extended version.
     - `execute of template failed: template: docs/single.html:30:7: executing "docs/single.html" at <partial "scripts.html" .>: error calling partial`: You haven't run `npm install` in the `themes/docsy` directory.
+
+## Generating Markdown output for LLMs
+
+The site can be converted to Markdown files suitable for LLM consumption using the `hugo_to_markdown.py` script.
+
+### Prerequisites
+
+- Python 3.10+
+- Install the required Python packages:
+
+    ```bash
+    pip install beautifulsoup4 html2text
+    ```
+
+### Build and convert
+
+1. Build the site:
+
+    ```bash
+    hugo --minify
+    ```
+
+1. Run the conversion script (writes `.md` files alongside the HTML in `public/`):
+
+    ```bash
+    python3 themes/docsy-axoflow/scripts/hugo_to_markdown.py --input public --output public
+    ```
+
+The script mirrors the Hugo output directory structure, converting each `index.html` to an `index.md` file in the same directory. Internal links are converted to relative Markdown links.

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -29,6 +29,24 @@ description = "Documentation for AxoSyslog, the scalable security data processor
     home = ["HTML", "print"]
     # Enable print this section menu item
     section = [ "HTML", "print" ]
+    page = ["HTML"]
+
+# output for llm bots
+[outputFormats.llms]
+  name        = "llms"
+  baseName    = "llms"
+  mediaType   = "text/plain"
+  isPlainText = true
+
+## For llms.txt/markdown output rendering with `hugo serve`
+[[server.headers]]
+  for = "**.md"
+  [server.headers.values]
+    Content-Type = "text/markdown; charset=utf-8"
+[[server.headers]]
+  for = "**.txt"
+  [server.headers.values]
+    Content-Type = "text/plain; charset=utf-8"
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
When publishing a production build: 
- Convert every index.html to markdown using a python script (index.md, placed next to the html file)
- Add a link rel="alternate" tag from the html to the markdown file
- Adds a basic llms.txt file to the root output
