### PR TITLE
Crosslinks for use-dns() option

### DIFF
--- a/content/chapter-examples/examples-dns/_index.md
+++ b/content/chapter-examples/examples-dns/_index.md
@@ -7,18 +7,18 @@ weight: 300
 The AxoSyslog application can resolve the hostnames of the clients and include them in the log messages. However, the performance of AxoSyslog is severely degraded if the domain name server is unaccessible or slow. Therefore, it is not recommended to resolve hostnames in `syslog-ng`. If you must use name resolution from `syslog-ng`, consider the following:
 
 - Use DNS caching. Verify that the DNS cache is large enough to store all important hostnames. (By default, the AxoSyslog DNS cache stores `1007` entries.)
-    
+
     ```shell
-        options { dns-cache-size(2000); };
+    options { dns-cache-size(2000); };
     ```
 
 - If the IP addresses of the clients change only rarely, set the expiry of the DNS cache large.
-    
+
     ```shell
-        options { dns-cache-expire(87600); };
+    options { dns-cache-expire(87600); };
     ```
 
-- If possible, resolve the hostnames locally. For details, see {{% xref "/chapter-examples/examples-dns/example-local-dns/_index.md" %}}.
+- If possible, resolve the hostnames locally using the `use-dns()` option. For details, see {{% xref "/chapter-examples/examples-dns/example-local-dns/_index.md" %}}.
 
 {{% alert title="Note" color="info" %}}
 Domain name resolution is important mainly in relay and server mode.

--- a/content/headless/chunk/option-source-use-dns.md
+++ b/content/headless/chunk/option-source-use-dns.md
@@ -6,9 +6,11 @@
 
 |          |                        |
 | -------- | ---------------------- |
-| Type:    | yes, no, persist_only |
-| Default: | yes                    |
+| Type:    | `yes`, `no`, `persist_only` |
+| Default: | `yes`                    |
 
-*Description:* Enable or disable DNS usage. The `persist_only` option attempts to resolve hostnames locally from file (for example, from `/etc/hosts`). The {{% param "product.abbrev" %}} application blocks on DNS queries, so enabling DNS may lead to a Denial of Service attack. To prevent DoS, protect your AxoSyslog network endpoint with firewall rules, and make sure that all hosts which may get to AxoSyslog are resolvable. This option can be specified globally, and per-source as well. The local setting of the source overrides the global option if available.
+*Description:* Enable or disable DNS usage. The `persist_only` option attempts to resolve hostnames locally from a file (for example, from `/etc/hosts`) set using the [`dns-cache-hosts()` global option]({{< relref "/chapter-global-options/reference-options/_index.md#global-option-dns-cache-hosts" >}}). The {{% param "product.abbrev" %}} application blocks on DNS queries, so enabling DNS may lead to a Denial of Service attack. To prevent DoS, protect your AxoSyslog network endpoint with firewall rules, and make sure that all hosts which may get to AxoSyslog are resolvable. This option can be specified globally, and per-source as well. The local setting of the source overrides the global option if available.
+
+For details on configuring local DNS resolution, see {{% xref "/chapter-examples/examples-dns/_index.md" %}}.
 
 {{< include-headless "chunk/p-keep-hostname.md" >}}


### PR DESCRIPTION
Formatting fixes and crosslinks for use-dns() option