### PR TITLE
[4.25] Adds input_transport_errors_total metric to reference page

### DIFF
--- a/content/chapter-log-statistics/metrics-reference/_index.md
+++ b/content/chapter-log-statistics/metrics-reference/_index.md
@@ -69,6 +69,15 @@ The following list shows the metrics available in {{< product >}}.
 
 *Description*: Number of incoming log messages processed by each source.
 
+## input_transport_errors_total
+
+*Description*: Number of various transport errors that prevent {{< product >}} from ingesting messages, for example, TLS handshake errors or syslog framing errors. Labels include the source `id`, `peer_address`, and the `reason` for the error. The `reason=unknown` label occurs when plain TCP traffic is received on a TLS source.
+
+```shell
+syslogng_input_transport_errors_total{address="127.0.0.1:5513",driver="syslog",peer_address="127.0.0.1",reason="invalid-frame-header",transport="tcp"} 1
+syslogng_input_transport_errors_total{address="127.0.0.1:5515",driver="syslog",id="s_tls_req#0",peer_address="127.0.0.1",reason="tls-handshake",tls_error="0A0000C7",tls_error_string="SSL routines::peer did not return a certificate",transport="tls"} 1
+```
+
 ## input_window_available
 
 *Description*: Available on `stats(level(3))`. Shows the current size of the flow-control window (how much is still free from `log-iw-size()`).

--- a/content/chapter-log-statistics/metrics-reference/_index.md
+++ b/content/chapter-log-statistics/metrics-reference/_index.md
@@ -71,7 +71,7 @@ The following list shows the metrics available in {{< product >}}.
 
 ## input_transport_errors_total
 
-*Description*: Number of various transport errors that prevent {{< product >}} from ingesting messages, for example, TLS handshake errors or syslog framing errors. Labels include the source `id`, `peer_address`, and the `reason` for the error. The `reason=unknown` label occurs when plain TCP traffic is received on a TLS source.
+*Description*: Number of various transport errors that prevent {{< product >}} from ingesting messages, for example, TLS handshake errors or syslog framing errors. Labels include the source `id`, `peer_address`, and the `reason` for the error.
 
 ```shell
 syslogng_input_transport_errors_total{address="127.0.0.1:5513",driver="syslog",peer_address="127.0.0.1",reason="invalid-frame-header",transport="tcp"} 1


### PR DESCRIPTION
https://github.com/axoflow/axosyslog/pull/1026/